### PR TITLE
chore: add GitHub templates and README

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @ansxuman

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Clauge
+
+Thank you for your interest in contributing to Clauge! We welcome contributions from the community.
+
+## Getting Started
+
+1. Fork the repository
+2. Clone your fork: `git clone https://github.com/your-username/Clauge.git`
+3. Install dependencies: `bun install`
+4. Run in development: `bun run tauri dev`
+
+## Development
+
+### Prerequisites
+
+- [Bun](https://bun.sh) (latest)
+- [Rust](https://rustup.rs) (1.77+)
+- [Tauri CLI](https://tauri.app) v2
+
+### Project Structure
+
+- `src/` — SvelteKit frontend (Svelte 5)
+- `src-tauri/` — Rust backend (Tauri v2)
+- `src-tauri/src/lib.rs` — Core logic (PTY, sessions, commands)
+- `src-tauri/scripts/` — Helper binaries (usage fetcher)
+
+## Submitting Changes
+
+1. Create a feature branch from `main`
+2. Make your changes
+3. Ensure `bun run build` passes
+4. Ensure `cargo check` passes in `src-tauri/`
+5. Submit a pull request
+
+## Code Style
+
+- Frontend: JavaScript with Svelte 5 runes (`$state`, `$derived`, `$effect`)
+- Backend: Rust with standard formatting (`cargo fmt`)
+- Use the existing patterns in the codebase
+
+## Reporting Issues
+
+Please use the issue templates when creating new issues.

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+buy_me_a_coffee: ansxuman

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,29 @@
+---
+name: Bug Report
+about: Report a bug to help us improve Clauge
+title: "[BUG] "
+labels: bug
+assignees: ansxuman
+---
+
+## Describe the Bug
+A clear and concise description of what the bug is.
+
+## Steps to Reproduce
+1. Go to '...'
+2. Click on '...'
+3. See error
+
+## Expected Behavior
+A clear description of what you expected to happen.
+
+## Screenshots
+If applicable, add screenshots to help explain your problem.
+
+## Environment
+- **OS**: [e.g. macOS 15.3]
+- **Clauge Version**: [e.g. 0.1.0]
+- **Architecture**: [e.g. arm64, x86_64]
+
+## Additional Context
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,2 @@
+blank_issues_enabled: false
+contact_links: []

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,19 @@
+---
+name: Feature Request
+about: Suggest a new feature for Clauge
+title: "[FEATURE] "
+labels: enhancement
+assignees: ansxuman
+---
+
+## Problem Description
+A clear description of what problem this feature would solve.
+
+## Proposed Solution
+A clear description of what you'd like to happen.
+
+## Alternative Solutions
+Any alternative solutions or features you've considered.
+
+## Additional Context
+Add any mockups, screenshots, or other context about the feature request.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+## Description
+<!-- Describe the changes made in this PR -->
+
+Fixes #
+
+## Type of Change
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] UI/UX improvement
+- [ ] Documentation update
+
+## Testing
+<!-- Describe how to test the changes -->
+
+## Checklist
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have tested my changes locally
+- [ ] My changes generate no new warnings
+- [ ] New and existing unit tests pass locally

--- a/README.md
+++ b/README.md
@@ -1,1 +1,117 @@
-# Clauge
+<p align="center">
+  <img src="src-tauri/icons/icon.png" alt="Clauge" width="140" />
+</p>
+
+<h1 align="center">Clauge</h1>
+
+<p align="center">
+  <strong>Visual session manager for Claude Code — organize, label, and resume sessions effortlessly</strong>
+</p>
+
+<p align="center">
+  <a href="https://github.com/ansxuman/Clauge/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-7c5cf8?style=flat-square" alt="License"></a>
+  <a href="https://github.com/ansxuman/Clauge/stargazers"><img src="https://img.shields.io/github/stars/ansxuman/Clauge?style=flat-square&color=f5a623" alt="Stars"></a>
+  <a href="https://github.com/ansxuman/Clauge/issues"><img src="https://img.shields.io/github/issues/ansxuman/Clauge?style=flat-square&color=4f94d4" alt="Issues"></a>
+  <a href="https://github.com/ansxuman/Clauge/releases/latest"><img src="https://img.shields.io/github/v/release/ansxuman/Clauge?style=flat-square&color=1dc880" alt="Release"></a>
+</p>
+
+<p align="center">
+  <a href="https://github.com/ansxuman/Clauge/issues">Report Bug</a> ·
+  <a href="https://github.com/ansxuman/Clauge/issues">Request Feature</a> ·
+  <a href="https://buymeacoffee.com/ansxuman">Buy me a coffee</a>
+</p>
+
+---
+
+## The Problem
+
+When using Claude Code (`claude` CLI), you can resume sessions with `claude --resume`. But in the terminal, it's impossible to know which session belongs to which project or what the purpose of that session was. Session IDs are UUIDs buried in `~/.claude/projects/`.
+
+## The Solution
+
+Clauge gives you a visual, organized way to manage, label, and resume Claude Code sessions — all from a native macOS desktop app with an embedded terminal.
+
+## Features
+
+- **Session Profiles** — Create labeled sessions with title and purpose (Brainstorming, Development, Code Review, Debugging)
+- **Project Grouping** — Sessions organized by project folder with expand/collapse
+- **Embedded Terminal** — Full xterm.js terminal with PTY — no external terminal needed
+- **Multi-Session** — Switch between active sessions instantly without re-spawning
+- **Auto-Discovery** — Automatically finds and links existing Claude Code sessions
+- **Usage Tracking** — Real-time session and weekly usage limits in the menu bar
+- **macOS Native** — Vibrancy sidebar, hidden titlebar, system tray, dark/light themes
+- **Keyboard Shortcuts** — `Cmd+N` new session, `Cmd+1-9` switch sessions
+- **Theme Engine** — Dark and light themes with 6 accent color options
+- **Context Injection** — Purpose-based context prompts auto-injected when starting sessions
+
+## Download
+
+<p>
+  <a href="https://github.com/ansxuman/Clauge/releases/latest"><strong>Download for macOS →</strong></a>
+</p>
+
+> macOS only. Built with native macOS APIs (vibrancy, keychain, NSURLSession).
+
+## Development
+
+### Prerequisites
+
+- [Bun](https://bun.sh) (latest)
+- [Rust](https://rustup.rs) (1.77+)
+- [Tauri CLI](https://tauri.app) v2
+
+### Setup
+
+```bash
+# Clone the repository
+git clone https://github.com/ansxuman/Clauge.git
+cd Clauge
+
+# Install dependencies
+bun install
+
+# Run in development mode
+bun run tauri dev
+
+# Build for production
+bun run tauri build
+```
+
+### Compile the usage fetcher (optional)
+
+```bash
+swiftc -O -o src-tauri/scripts/fetch_usage src-tauri/scripts/fetch_usage.swift
+```
+
+## Tech Stack
+
+| Layer | Technology |
+|-------|-----------|
+| Frontend | SvelteKit + Svelte 5 |
+| Backend | Rust + Tauri v2 |
+| Terminal | xterm.js + portable-pty |
+| Styling | CSS variables + macOS vibrancy |
+| Usage API | Swift (NSURLSession) |
+| Package Manager | Bun |
+
+## Usage Tracking Setup
+
+To see real-time usage limits in the menu bar:
+
+1. Open **Settings** (gear icon) → **Usage** tab
+2. Get your session key: Open `claude.ai` in browser → DevTools (F12) → Application → Cookies → copy `sessionKey` value
+3. Paste and save — usage refreshes every 5 minutes
+
+## Contributing
+
+See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines.
+
+## License
+
+[MIT](LICENSE)
+
+---
+
+<p align="center">
+  Made by <a href="https://github.com/ansxuman">@ansxuman</a>
+</p>


### PR DESCRIPTION
## Summary
- Add `.github/` config: CODEOWNERS, CONTRIBUTING.md, FUNDING.yml, PR template, issue templates (bug report, feature request)
- Replace boilerplate README with full project documentation (features, setup, tech stack, usage tracking)

## Test plan
- [ ] Verify issue templates appear when creating new issues
- [ ] Verify PR template loads on new PRs
- [ ] Verify Buy Me a Coffee sponsor button appears on repo page

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated README with complete project documentation, feature list, and setup instructions
  * Added detailed contribution guidelines with development prerequisites and setup steps
  * Added GitHub issue templates for bug reports and feature requests
  * Added pull request template with standardized review checklist
  * Configured code ownership and repository funding metadata

<!-- end of auto-generated comment: release notes by coderabbit.ai -->