### PR TITLE
fix: correct license to Apache 2.0 and remove footer

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 </p>
 
 <p align="center">
-  <a href="https://github.com/ansxuman/Clauge/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-MIT-7c5cf8?style=flat-square" alt="License"></a>
+  <a href="https://github.com/ansxuman/Clauge/blob/main/LICENSE"><img src="https://img.shields.io/badge/license-Apache%202.0-7c5cf8?style=flat-square" alt="License"></a>
   <a href="https://github.com/ansxuman/Clauge/stargazers"><img src="https://img.shields.io/github/stars/ansxuman/Clauge?style=flat-square&color=f5a623" alt="Stars"></a>
   <a href="https://github.com/ansxuman/Clauge/issues"><img src="https://img.shields.io/github/issues/ansxuman/Clauge?style=flat-square&color=4f94d4" alt="Issues"></a>
   <a href="https://github.com/ansxuman/Clauge/releases/latest"><img src="https://img.shields.io/github/v/release/ansxuman/Clauge?style=flat-square&color=1dc880" alt="Release"></a>
@@ -108,10 +108,4 @@ See [CONTRIBUTING.md](.github/CONTRIBUTING.md) for guidelines.
 
 ## License
 
-[MIT](LICENSE)
-
----
-
-<p align="center">
-  Made by <a href="https://github.com/ansxuman">@ansxuman</a>
-</p>
+[Apache License 2.0](LICENSE)


### PR DESCRIPTION
## Summary
- Fix license badge from MIT to Apache 2.0 to match the actual LICENSE file
- Remove "Made by" footer

## Test plan
- [ ] Verify license badge shows "Apache 2.0"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated license information in README from MIT to Apache License 2.0

<!-- end of auto-generated comment: release notes by coderabbit.ai -->