### PR TITLE
feat: auto git worktree isolation for multi-session projects

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -27,6 +27,10 @@ pub struct SessionProfile {
     pub context_prompt: String,
     pub created_at: String,
     pub last_used_at: String,
+    #[serde(default)]
+    pub worktree_path: Option<String>,
+    #[serde(default)]
+    pub worktree_branch: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -232,6 +236,8 @@ fn create_profile(title: String, purpose: String, project_path: String) -> Resul
         context_prompt: get_context_prompt(&purpose),
         created_at: now.clone(),
         last_used_at: now,
+        worktree_path: None,
+        worktree_branch: None,
     };
 
     profiles.push(profile.clone());
@@ -301,6 +307,104 @@ fn update_session_id(id: String, claude_session_id: String) -> Result<(), String
     }
     save_profiles(&profiles)?;
     Ok(())
+}
+
+/// Check if a path is inside a git repo
+#[tauri::command]
+fn is_git_repo(path: String) -> Result<bool, String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", &path, "rev-parse", "--is-inside-work-tree"])
+        .output()
+        .map_err(|e| e.to_string())?;
+    Ok(output.status.success())
+}
+
+/// Create a git worktree for session isolation
+#[tauri::command]
+fn create_worktree(project_path: String, branch_name: String) -> Result<String, String> {
+    // Worktree goes inside a hidden directory in the project
+    let worktree_dir = PathBuf::from(&project_path)
+        .join(".clauge-worktrees")
+        .join(&branch_name);
+    let worktree_path = worktree_dir.to_string_lossy().to_string();
+
+    // Create parent dir
+    let _ = std::fs::create_dir_all(worktree_dir.parent().unwrap_or(&worktree_dir));
+
+    // Create worktree with new branch
+    let output = std::process::Command::new("git")
+        .args(["-C", &project_path, "worktree", "add", "-b", &branch_name, &worktree_path])
+        .output()
+        .map_err(|e| format!("git worktree add failed: {}", e))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        // Branch might already exist — try without -b
+        if stderr.contains("already exists") {
+            let output2 = std::process::Command::new("git")
+                .args(["-C", &project_path, "worktree", "add", &worktree_path, &branch_name])
+                .output()
+                .map_err(|e| format!("git worktree add (existing branch) failed: {}", e))?;
+            if !output2.status.success() {
+                return Err(format!("git worktree add failed: {}", String::from_utf8_lossy(&output2.stderr)));
+            }
+        } else {
+            return Err(format!("git worktree add failed: {}", stderr));
+        }
+    }
+
+    // Add .clauge-worktrees to .gitignore if not already there
+    let gitignore = PathBuf::from(&project_path).join(".gitignore");
+    if let Ok(contents) = std::fs::read_to_string(&gitignore) {
+        if !contents.contains(".clauge-worktrees") {
+            let _ = std::fs::write(&gitignore, format!("{}\n.clauge-worktrees/\n", contents.trim_end()));
+        }
+    } else {
+        let _ = std::fs::write(&gitignore, ".clauge-worktrees/\n");
+    }
+
+    Ok(worktree_path)
+}
+
+/// Remove a git worktree
+#[tauri::command]
+fn remove_worktree(project_path: String, worktree_path: String) -> Result<(), String> {
+    let output = std::process::Command::new("git")
+        .args(["-C", &project_path, "worktree", "remove", "--force", &worktree_path])
+        .output()
+        .map_err(|e| format!("git worktree remove failed: {}", e))?;
+
+    if !output.status.success() {
+        // If worktree dir is already gone, just prune
+        let _ = std::process::Command::new("git")
+            .args(["-C", &project_path, "worktree", "prune"])
+            .output();
+    }
+    Ok(())
+}
+
+/// Update worktree info for a profile
+#[tauri::command]
+fn update_profile_worktree(id: String, worktree_path: Option<String>, worktree_branch: Option<String>) -> Result<(), String> {
+    let mut profiles = load_profiles();
+    if let Some(profile) = profiles.iter_mut().find(|p| p.id == id) {
+        profile.worktree_path = worktree_path;
+        profile.worktree_branch = worktree_branch;
+    } else {
+        return Err("Profile not found".to_string());
+    }
+    save_profiles(&profiles)?;
+    Ok(())
+}
+
+/// Count active sessions for a project path (profiles that have been used)
+#[tauri::command]
+fn count_project_sessions(project_path: String) -> Result<u32, String> {
+    let profiles = load_profiles();
+    let count = profiles.iter()
+        .filter(|p| p.project_path == project_path)
+        .count() as u32;
+    Ok(count)
 }
 
 #[tauri::command]
@@ -694,6 +798,11 @@ pub fn run() {
             update_last_used,
             refresh_session_ids,
             update_session_id,
+            is_git_repo,
+            create_worktree,
+            remove_worktree,
+            update_profile_worktree,
+            count_project_sessions,
             discover_sessions,
             get_session_tokens,
             fetch_usage_limits,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -180,6 +180,38 @@
 
       try {
         await invoke("update_last_used", { id: profile.id });
+
+        // Determine working directory — use worktree if already set, or create one if needed
+        let spawnPath = profile.worktreePath || profile.projectPath;
+
+        if (!profile.worktreePath) {
+          // Check if another session for this project already has a terminal running
+          const otherActive = profiles.some(p =>
+            p.id !== profile.id &&
+            p.projectPath === profile.projectPath &&
+            terminalMap.has(p.id) &&
+            terminalMap.get(p.id).terminalId
+          );
+
+          if (otherActive) {
+            // Need worktree isolation — check if it's a git repo first
+            try {
+              const isGit = await invoke("is_git_repo", { path: profile.projectPath });
+              if (isGit) {
+                const branchName = `clauge/${profile.purpose.toLowerCase().replace(/\s+/g, '-')}-${profile.title.toLowerCase().replace(/\s+/g, '-')}`;
+                const worktreePath = await invoke("create_worktree", { projectPath: profile.projectPath, branchName });
+                spawnPath = worktreePath;
+                await invoke("update_profile_worktree", { id: profile.id, worktreePath, worktreeBranch: branchName });
+                profile.worktreePath = worktreePath;
+                profile.worktreeBranch = branchName;
+                await loadProfiles();
+              }
+            } catch(e) {
+              console.warn("Worktree creation failed, using original path:", e);
+            }
+          }
+        }
+
         const onOutput = new Channel();
         onOutput.onmessage = (payload) => {
           if (entry.term) {
@@ -195,7 +227,7 @@
 
         const tid = await invoke("spawn_terminal", {
           sessionId: profile.claudeSessionId || null,
-          projectPath: profile.projectPath,
+          projectPath: spawnPath,
           contextPrompt: profile.contextPrompt,
           onOutput: onOutput,
         });
@@ -414,6 +446,9 @@
                     </div>
                     <div class="profile-meta">
                       <span class="badge" style="color:{purposeColors[profile.purpose] || '#8b949e'}; background:{purposeColors[profile.purpose] || '#8b949e'}22">{profile.purpose}</span>
+                      {#if profile.worktreeBranch}
+                        <span class="wt-badge" title="Isolated worktree: {profile.worktreeBranch}">WT</span>
+                      {/if}
                       <span class="time">{relativeTime(profile.lastUsedAt)}</span>
                     </div>
                   </button>
@@ -657,6 +692,7 @@
   .profile-title { font-size: 13px; font-weight: 500; color: var(--text-primary); margin-bottom: 3px; }
   .profile-meta { display: flex; align-items: center; justify-content: space-between; }
   .badge { font-size: 10px; font-weight: 600; padding: 1px 6px; border-radius: 10px; }
+  .wt-badge { font-size: 8px; font-weight: 700; padding: 1px 4px; border-radius: 3px; background: rgba(210, 168, 255, 0.2); color: #d2a8ff; letter-spacing: 0.5px; }
   .time { font-size: 11px; color: var(--text-secondary); }
   .bottom-bar { display: flex; align-items: center; justify-content: center; gap: 16px; padding: 4px 16px; background: var(--sidebar-bg); border-top: 1px solid var(--border); flex-shrink: 0; }
   .limit-meter { display: flex; align-items: center; gap: 6px; }


### PR DESCRIPTION
## Summary
- When a second session opens for a project that already has an active terminal, Clauge auto-creates a git worktree
- First session uses the original project directory (zero overhead)
- Subsequent sessions get isolated worktrees at `.clauge-worktrees/<branch>/`
- `.clauge-worktrees/` auto-added to `.gitignore`
- Non-git projects silently fall back to shared directory
- Sidebar shows "WT" badge on worktree sessions

## New Rust commands
- `is_git_repo` — checks if path is a git repo
- `create_worktree` — runs `git worktree add` with branch
- `remove_worktree` — runs `git worktree remove --force`
- `update_profile_worktree` — stores worktree path/branch in profile
- `count_project_sessions` — counts sessions for a project

## Test plan
- [ ] Create two sessions for the same git project
- [ ] First session runs in original directory
- [ ] Second session auto-creates worktree (check `.clauge-worktrees/` exists)
- [ ] Both terminals run independently without file conflicts
- [ ] WT badge appears on worktree session in sidebar
- [ ] Non-git project: second session runs without error (no worktree)

Fixes #17