### PR TITLE
feat: CLAUDE.md injection for purpose-driven sessions

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 <h1 align="center">Clauge</h1>
 
 <p align="center">
-  Session manager for Claude Code
+  A lightweight, native macOS app for running multiple Claude Code sessions side by side — with purpose-driven workflows, embedded terminal, and automatic session isolation.
 </p>
 
 <p align="center">
@@ -23,18 +23,31 @@
 
 ---
 
-## Features
+## Why Clauge?
 
-- **Session profiles** with title and purpose — Brainstorming, Development, Code Review, Debugging
-- **Embedded terminal** (xterm.js + PTY) — no external terminal window needed
-- **Multi-session** — switch between active sessions without re-spawning
-- **Project grouping** with expand/collapse
-- **Auto-discovery** of existing Claude Code sessions from `~/.claude/projects/`
-- **Usage tracking** — session and weekly limits shown in the menu bar
-- **macOS native** — vibrancy, hidden titlebar, system tray
-- **Dark & light themes** with accent color picker
-- **Keyboard shortcuts** — `Cmd+N`, `Cmd+1-9`
-- **Context prompts** — auto-injected based on session purpose
+Claude Code's `--resume` expects you to remember UUID session IDs. When you're juggling brainstorming, development, and code review across multiple projects, that falls apart fast.
+
+Clauge gives every session a name, a purpose, and its own terminal — all inside a single native app that weighs under 10MB and barely touches your CPU.
+
+## What it does
+
+### Purpose-driven sessions
+Pick a purpose when you create a session — **Brainstorming**, **Development**, **Code Review**, or **Debugging**. Clauge writes a `CLAUDE.md` file with tailored instructions so Claude stays in the right mindset throughout the session. Not a one-time prompt — it persists on every turn.
+
+### Run sessions in parallel
+Open multiple sessions for the same project without worrying about file conflicts. Clauge automatically creates **git worktrees** to isolate each session. First session runs in your project directory, second gets its own branch and working copy.
+
+### Embedded terminal
+Full interactive terminal (xterm.js + PTY) built into the app. Colors, scrollback, resize — everything works. Switch between sessions instantly without re-spawning Claude.
+
+### Lightweight and native
+Built with **Rust + Tauri**. ~10MB app size. Uses macOS native APIs — translucent vibrancy sidebar, system tray with usage stats, hidden titlebar with traffic lights. Runs with minimal memory and CPU compared to Electron alternatives.
+
+### Usage tracking
+See your Claude session and weekly usage limits right in the menu bar. Pulls real data from the Claude API — no guessing how much headroom you have left.
+
+### Organize everything
+Sessions grouped by project with expand/collapse. Auto-discovers existing Claude Code sessions from `~/.claude/projects/`. Dark and light themes with accent colors. Keyboard shortcuts for everything.
 
 ## Download
 
@@ -53,12 +66,13 @@ bun run tauri dev
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Frontend | SvelteKit + Svelte 5 |
-| Backend | Rust + Tauri v2 |
-| Terminal | xterm.js + portable-pty |
-| Usage API | Swift (NSURLSession) |
+| | |
+|---|---|
+| **Frontend** | SvelteKit, Svelte 5 |
+| **Backend** | Rust, Tauri v2 |
+| **Terminal** | xterm.js, portable-pty |
+| **Session isolation** | git worktrees |
+| **Usage API** | Swift (NSURLSession) |
 
 ## Contributing
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -93,12 +93,83 @@ impl Default for TerminalState {
 
 fn get_context_prompt(purpose: &str) -> String {
     match purpose {
-        "Brainstorming" => "This is a brainstorming session. Help me explore ideas, ask clarifying questions, and think through approaches before committing to implementation.".to_string(),
-        "Development" => "This is a development session. Help me write, refactor, and improve code. Focus on implementation quality and best practices.".to_string(),
-        "Code Review" => "This is a code review session. Help me review code for bugs, improvements, and best practices. Be critical and thorough.".to_string(),
-        "Debugging" => "This is a debugging session. Help me systematically identify and fix bugs. Ask about symptoms, reproduce issues, and trace root causes.".to_string(),
+        "Brainstorming" => r#"# Session: Brainstorming
+
+You are in a brainstorming session. Your role:
+
+- Explore multiple approaches before settling on one
+- Ask clarifying questions to understand the full picture
+- Think out loud — share tradeoffs, risks, and alternatives
+- Do NOT write implementation code unless explicitly asked
+- Focus on architecture, design decisions, and high-level strategy
+- Challenge assumptions — push back if something seems off
+- Summarize options with pros/cons when presenting choices"#.to_string(),
+
+        "Development" => r#"# Session: Development
+
+You are in a development session. Your role:
+
+- Write clean, working code — prioritize correctness over cleverness
+- Follow existing patterns and conventions in the codebase
+- Make small, focused changes — one thing at a time
+- Run tests and verify changes work before moving on
+- Keep commits logical and atomic
+- If requirements are unclear, ask before guessing
+- Prefer editing existing files over creating new ones"#.to_string(),
+
+        "Code Review" => r#"# Session: Code Review
+
+You are in a code review session. Your role:
+
+- Review recent changes with a critical eye
+- Check for: bugs, security issues, performance problems, edge cases
+- Reference specific files and line numbers
+- Suggest concrete improvements, not vague advice
+- Flag anything that could break in production
+- Check error handling — are failures handled gracefully?
+- Look for missing tests or untested paths
+- Be direct — don't sugarcoat issues"#.to_string(),
+
+        "Debugging" => r#"# Session: Debugging
+
+You are in a debugging session. Your role:
+
+- Reproduce the issue first — confirm the symptoms
+- Form a hypothesis, then verify it with evidence (logs, output, traces)
+- Do NOT guess fixes — trace the root cause methodically
+- Check recent changes that might have introduced the bug
+- Use binary search (git bisect, selective commenting) to isolate
+- Once found, explain the root cause before proposing a fix
+- After fixing, verify the original issue is resolved
+- Check for related bugs that might have the same root cause"#.to_string(),
+
         _ => String::new(),
     }
+}
+
+/// Write a CLAUDE.md file in the session's working directory
+/// Claude Code reads this automatically on every turn
+fn inject_claude_md(working_dir: &str, purpose: &str, title: &str) -> Result<(), String> {
+    let prompt = get_context_prompt(purpose);
+    if prompt.is_empty() { return Ok(()); }
+
+    let claude_dir = PathBuf::from(working_dir).join(".claude");
+    let _ = std::fs::create_dir_all(&claude_dir);
+    let md_path = claude_dir.join("CLAUDE.md");
+
+    // Don't overwrite if it already exists (user may have customized it)
+    if md_path.exists() {
+        let existing = std::fs::read_to_string(&md_path).unwrap_or_default();
+        if existing.contains("# Session:") {
+            // Our file — safe to update
+            std::fs::write(&md_path, &prompt).map_err(|e| e.to_string())?;
+        }
+        // User's custom file — leave it alone
+    } else {
+        std::fs::write(&md_path, &prompt).map_err(|e| e.to_string())?;
+    }
+
+    Ok(())
 }
 
 // ---------------------------------------------------------------------------
@@ -707,7 +778,18 @@ fn spawn_terminal(
         }
     });
 
-    let _ = context_prompt;
+    // Inject CLAUDE.md if this is a new session (no session_id = first run)
+    if session_id.is_none() {
+        if let Some(ref prompt) = context_prompt {
+            if !prompt.is_empty() {
+                // prompt format: "purpose|title" — extract and inject CLAUDE.md
+                let parts: Vec<&str> = prompt.splitn(2, '|').collect();
+                if parts.len() == 2 {
+                    let _ = inject_claude_md(&project_path, parts[0], parts[1]);
+                }
+            }
+        }
+    }
 
     let entry = TerminalEntry {
         master: pty_pair.master,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -244,7 +244,7 @@
         const tid = await invoke("spawn_terminal", {
           sessionId: profile.claudeSessionId || null,
           projectPath: spawnPath,
-          contextPrompt: profile.contextPrompt,
+          contextPrompt: `${profile.purpose}|${profile.title}`,
           onOutput: onOutput,
         });
         entry.terminalId = tid;


### PR DESCRIPTION
## Summary

### CLAUDE.md injection
- New sessions now write a `.claude/CLAUDE.md` file in the working directory
- Claude Code reads this on every turn — not a one-time prompt
- Rich, purpose-specific instructions for each session type
- Doesn't overwrite user-customized CLAUDE.md files
- Only writes on new sessions (not resume)

### README rewrite
- Highlights what makes Clauge different: lightweight Rust/Tauri, parallel sessions, worktree isolation, purpose-driven workflows
- Reads naturally, not like AI-generated marketing copy
- Updated repo description

## Test plan
- [ ] Create a Brainstorming session — verify `.claude/CLAUDE.md` is created with brainstorming instructions
- [ ] Create a Development session — verify different instructions
- [ ] Resume an existing session — verify CLAUDE.md is NOT overwritten
- [ ] Verify Claude responds in the context of the purpose