### PR TITLE
fix: resume worktree sessions using original project path

### DIFF
--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -197,8 +197,13 @@
       try {
         await invoke("update_last_used", { id: profile.id });
 
-        // Determine working directory — use worktree if already set, or create one if needed
-        let spawnPath = profile.worktreePath || profile.projectPath;
+        // Determine working directory:
+        // - Resuming a session: always use original project path (Claude stores sessions by project root)
+        // - New session with worktree: use worktree path for file isolation
+        // - New session without worktree: use original project path
+        let spawnPath = profile.claudeSessionId
+          ? profile.projectPath  // resuming — Claude needs the original project path
+          : (profile.worktreePath || profile.projectPath);
 
         if (!profile.worktreePath) {
           // Check if another session for this project already has a terminal running


### PR DESCRIPTION
## Summary
Claude Code stores sessions indexed by the project root path, not the worktree path. When resuming a worktree session, Clauge was passing the worktree path to `claude --resume`, causing "No conversation found" errors.

Now:
- **Resume** (has sessionId) → always uses original `projectPath`
- **New session** (no sessionId) → uses worktree path if set, for file isolation

## Test plan
- [ ] Create two sessions for the same project (triggers worktree)
- [ ] Close app, reopen
- [ ] Click the worktree session — should resume without errors