### PR TITLE
fix: generate latest.json for tauri updater

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -43,6 +43,39 @@ jobs:
       - name: Build macOS (x86_64)
         run: bun run tauri build --target x86_64-apple-darwin
 
+      - name: Generate latest.json for updater
+        if: github.event_name == 'release'
+        run: |
+          VERSION="${GITHUB_REF_NAME#v}"
+          REPO="${{ github.repository }}"
+
+          # Find the .tar.gz and .sig files for the updater
+          ARM_TAR=$(ls src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+          X86_TAR=$(ls src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz 2>/dev/null | head -1)
+          ARM_SIG=$(cat "${ARM_TAR}.sig" 2>/dev/null || echo "")
+          X86_SIG=$(cat "${X86_TAR}.sig" 2>/dev/null || echo "")
+
+          ARM_TAR_NAME=$(basename "$ARM_TAR")
+          X86_TAR_NAME=$(basename "$X86_TAR")
+
+          cat > latest.json << EOF
+          {
+            "version": "${VERSION}",
+            "notes": "See https://github.com/${REPO}/releases/tag/v${VERSION}",
+            "pub_date": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+            "platforms": {
+              "darwin-aarch64": {
+                "signature": "${ARM_SIG}",
+                "url": "https://github.com/${REPO}/releases/download/v${VERSION}/${ARM_TAR_NAME}"
+              },
+              "darwin-x86_64": {
+                "signature": "${X86_SIG}",
+                "url": "https://github.com/${REPO}/releases/download/v${VERSION}/${X86_TAR_NAME}"
+              }
+            }
+          }
+          EOF
+
       - name: Upload release assets
         if: github.event_name == 'release'
         uses: softprops/action-gh-release@v2
@@ -52,6 +85,9 @@ jobs:
             src-tauri/target/x86_64-apple-darwin/release/bundle/dmg/*.dmg
             src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz
             src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz
+            src-tauri/target/aarch64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
+            src-tauri/target/x86_64-apple-darwin/release/bundle/macos/*.app.tar.gz.sig
+            latest.json
 
       - name: Upload artifacts (for manual runs)
         if: github.event_name == 'workflow_dispatch'


### PR DESCRIPTION
## Summary
Build pipeline now generates `latest.json` and uploads it as a release asset. This is what `tauri-plugin-updater` checks to detect new versions.

Contains: version, pub_date, platform URLs (darwin-aarch64 + darwin-x86_64), signatures.

Also uploads `.sig` files for update verification.