### PR TITLE
fix: direct DMG download on website

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -30,9 +30,9 @@
     <h1 class="reveal">Run multiple Claude Code<br>sessions in parallel</h1>
     <p class="subtitle reveal reveal-delay-1">Organized by project, each with its own purpose and terminal.<br>Built with Rust + Tauri.</p>
     <div class="hero-buttons reveal reveal-delay-2">
-      <a href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
+      <a id="hero-download" href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
         <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"/></svg>
-        Download for macOS
+        <span class="dl-text">Download for macOS</span>
       </a>
       <a href="https://github.com/ansxuman/Clauge" class="btn-secondary">View on GitHub</a>
     </div>
@@ -271,9 +271,9 @@
   <div class="container reveal">
     <h2>Get Clauge</h2>
     <p class="sub">Free and open source.</p>
-    <a href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
+    <a id="cta-download" href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
       <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"/></svg>
-      Download for macOS
+      <span class="dl-text">Download for macOS</span>
     </a>
     <p class="below-btn"><a href="https://github.com/ansxuman/Clauge">View source on GitHub</a></p>
   </div>
@@ -314,6 +314,29 @@
   window.addEventListener('scroll', () => {
     header.classList.toggle('scrolled', window.scrollY > 20);
   }, { passive: true });
+
+  // Direct download — detect arch and link to the right DMG
+  (async function() {
+    try {
+      const resp = await fetch('https://api.github.com/repos/ansxuman/Clauge/releases/latest');
+      if (!resp.ok) return;
+      const release = await resp.json();
+      const isArm = navigator.userAgent.includes('ARM') || navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0;
+      const dmg = (release.assets || []).find(a =>
+        a.name.endsWith('.dmg') && (isArm ? a.name.includes('aarch64') : a.name.includes('x64') || a.name.includes('x86_64'))
+      ) || (release.assets || []).find(a => a.name.endsWith('.dmg'));
+
+      if (dmg) {
+        const url = dmg.browser_download_url;
+        const version = release.tag_name;
+        const arch = isArm ? 'Apple Silicon' : 'Intel';
+        document.querySelectorAll('#hero-download, #cta-download').forEach(el => {
+          el.href = url;
+          el.querySelector('.dl-text').textContent = `Download ${version} (${arch})`;
+        });
+      }
+    } catch(e) {}
+  })();
 
   // Session switcher — sidebar click + auto-cycle
   (function() {


### PR DESCRIPTION
## Summary
- Download buttons now fetch latest release from GitHub API
- Detects user's architecture (Apple Silicon vs Intel)
- Links directly to the correct DMG — no redirect to releases page
- Button text shows version and arch: "Download v0.1.0 (Apple Silicon)"
- Falls back to releases page if no release exists yet