### PR TITLE
fix: add actions:write permission for build trigger

### DIFF
--- a/.github/workflows/create-release.yml
+++ b/.github/workflows/create-release.yml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Create Release workflow needs actions:write to trigger Build Release via gh workflow run.