### PR TITLE
fix: bundle targets format

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -37,7 +37,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": ["dmg", "updater"],
+    "targets": "all",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Revert to `"targets": "all"` — the array format isn't valid in Tauri v2.