### PR TITLE
fix: bundle identifier, warnings, version bump script

### DIFF
--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# Usage: ./scripts/bump-version.sh 0.2.1
+set -e
+
+VERSION="$1"
+if [ -z "$VERSION" ]; then
+  echo "Usage: $0 <version>"
+  echo "Example: $0 0.2.1"
+  exit 1
+fi
+
+# Update all three files
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+  sed -i '' "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+  sed -i '' "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+else
+  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" src-tauri/tauri.conf.json
+  sed -i "s/\"version\": \"[^\"]*\"/\"version\": \"$VERSION\"/" package.json
+  sed -i "s/^version = \"[^\"]*\"/version = \"$VERSION\"/" src-tauri/Cargo.toml
+fi
+
+echo "Bumped to v$VERSION"
+echo ""
+echo "Next steps:"
+echo "  git add -A && git commit -m 'chore: bump version to $VERSION'"
+echo "  git tag v$VERSION && git push origin main --tags"

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 # Usage: ./scripts/bump-version.sh 0.2.1
+# Bumps version, commits, tags, and pushes — triggers the release pipeline
 set -e
 
 VERSION="$1"
@@ -21,7 +22,11 @@ else
 fi
 
 echo "Bumped to v$VERSION"
-echo ""
-echo "Next steps:"
-echo "  git add -A && git commit -m 'chore: bump version to $VERSION'"
-echo "  git tag v$VERSION && git push origin main --tags"
+
+# Commit, tag, push
+git add src-tauri/tauri.conf.json src-tauri/Cargo.toml package.json
+git commit -m "chore: bump version to $VERSION"
+git tag "v$VERSION"
+git push origin main --tags
+
+echo "Done — release pipeline triggered for v$VERSION"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -163,7 +163,7 @@ You are in a PR review session. Your role:
 
 /// Write a CLAUDE.md file in the session's working directory
 /// Claude Code reads this automatically on every turn
-fn inject_claude_md(working_dir: &str, purpose: &str, title: &str) -> Result<(), String> {
+fn inject_claude_md(working_dir: &str, purpose: &str, _title: &str) -> Result<(), String> {
     let prompt = get_context_prompt(purpose);
     if prompt.is_empty() { return Ok(()); }
 
@@ -610,28 +610,6 @@ fn get_session_tokens(
     })
 }
 
-fn get_session_key_from_keychain() -> Result<String, String> {
-    let output = std::process::Command::new("security")
-        .args(["find-generic-password", "-s", "Claude Code-credentials", "-w"])
-        .output()
-        .map_err(|e| format!("Keychain access failed: {}", e))?;
-
-    if !output.status.success() {
-        return Err("No Claude Code credentials in keychain".to_string());
-    }
-
-    let json_str = String::from_utf8(output.stdout)
-        .map_err(|e| format!("Invalid UTF-8: {}", e))?;
-
-    let parsed: serde_json::Value = serde_json::from_str(json_str.trim())
-        .map_err(|e| format!("JSON parse failed: {}", e))?;
-
-    parsed
-        .get("claudeAiOauth")
-        .and_then(|o| o.get("accessToken").and_then(|v| v.as_str()))
-        .map(|s| s.to_string())
-        .ok_or("No access token found in credentials".to_string())
-}
 
 /// Fetch usage limits via precompiled Swift binary (NSURLSession bypasses Cloudflare, ~1.5s)
 #[tauri::command]

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "https://schema.tauri.app/config/2",
   "productName": "Clauge",
   "version": "0.2.0",
-  "identifier": "com.clauge.app",
+  "identifier": "com.clauge.desktop",
   "build": {
     "beforeDevCommand": "bun run dev",
     "devUrl": "http://localhost:1420",


### PR DESCRIPTION
- Fix identifier from com.clauge.app to com.clauge.desktop
- Remove unused get_session_key_from_keychain function
- Fix unused title parameter warning
- Add scripts/bump-version.sh — one command to bump, commit, tag, push, and trigger release

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated application system identifier.
  * Added automated version management tooling.
  * Removed unused internal dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->