### PR TITLE
fix: session isolation — no shared state between sessions

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -161,30 +161,6 @@ You are in a PR review session. Your role:
     }
 }
 
-/// Write a CLAUDE.md file in the session's working directory
-/// Claude Code reads this automatically on every turn
-fn inject_claude_md(working_dir: &str, purpose: &str, _title: &str) -> Result<(), String> {
-    let prompt = get_context_prompt(purpose);
-    if prompt.is_empty() { return Ok(()); }
-
-    let claude_dir = PathBuf::from(working_dir).join(".claude");
-    let _ = std::fs::create_dir_all(&claude_dir);
-    let md_path = claude_dir.join("CLAUDE.md");
-
-    // Don't overwrite if it already exists (user may have customized it)
-    if md_path.exists() {
-        let existing = std::fs::read_to_string(&md_path).unwrap_or_default();
-        if existing.contains("# Session:") {
-            // Our file — safe to update
-            std::fs::write(&md_path, &prompt).map_err(|e| e.to_string())?;
-        }
-        // User's custom file — leave it alone
-    } else {
-        std::fs::write(&md_path, &prompt).map_err(|e| e.to_string())?;
-    }
-
-    Ok(())
-}
 
 // ---------------------------------------------------------------------------
 // Storage helpers
@@ -245,43 +221,6 @@ fn encode_project_path(project_path: &str) -> String {
     project_path.replace('/', "-")
 }
 
-fn discover_claude_session_id(project_path: &str) -> Option<String> {
-    let home = dirs::home_dir()?;
-    let encoded = encode_project_path(project_path);
-    let projects_dir = home.join(".claude").join("projects").join(&encoded);
-
-    if !projects_dir.exists() {
-        return None;
-    }
-
-    let mut best: Option<(String, std::time::SystemTime)> = None;
-
-    if let Ok(entries) = std::fs::read_dir(&projects_dir) {
-        for entry in entries.flatten() {
-            let path = entry.path();
-            if path.extension().and_then(|e| e.to_str()) == Some("jsonl") {
-                if let Ok(meta) = path.metadata() {
-                    if let Ok(modified) = meta.modified() {
-                        let session_id = path
-                            .file_stem()
-                            .and_then(|s| s.to_str())
-                            .unwrap_or("")
-                            .to_string();
-                        if let Some((_, best_time)) = &best {
-                            if modified > *best_time {
-                                best = Some((session_id, modified));
-                            }
-                        } else {
-                            best = Some((session_id, modified));
-                        }
-                    }
-                }
-            }
-        }
-    }
-
-    best.map(|(id, _)| id)
-}
 
 fn now_iso8601() -> String {
     chrono::Utc::now().to_rfc3339()
@@ -362,23 +301,11 @@ fn update_last_used(id: String) -> Result<(), String> {
     Ok(())
 }
 
-/// Refresh claudeSessionId for all profiles that have null session IDs
+/// Get all profiles — no auto-discovery of session IDs
+/// Session IDs are only set when explicitly captured after a session starts
 #[tauri::command]
 fn refresh_session_ids() -> Result<Vec<SessionProfile>, String> {
-    let mut profiles = load_profiles();
-    let mut changed = false;
-    for profile in profiles.iter_mut() {
-        if profile.claude_session_id.is_none() {
-            if let Some(sid) = discover_claude_session_id(&profile.project_path) {
-                profile.claude_session_id = Some(sid);
-                changed = true;
-            }
-        }
-    }
-    if changed {
-        save_profiles(&profiles)?;
-    }
-    Ok(profiles)
+    Ok(load_profiles())
 }
 
 /// Update the claude session ID for a specific profile
@@ -687,7 +614,7 @@ fn spawn_terminal(
     state: State<'_, TerminalState>,
     session_id: Option<String>,
     project_path: String,
-    context_prompt: Option<String>,
+    _context_prompt: Option<String>,
     on_output: Channel<TerminalOutputPayload>,
 ) -> Result<String, String> {
     let terminal_id = Uuid::new_v4().to_string();
@@ -775,19 +702,6 @@ fn spawn_terminal(
             }
         }
     });
-
-    // Inject CLAUDE.md if this is a new session (no session_id = first run)
-    if session_id.is_none() {
-        if let Some(ref prompt) = context_prompt {
-            if !prompt.is_empty() {
-                // prompt format: "purpose|title" — extract and inject CLAUDE.md
-                let parts: Vec<&str> = prompt.splitn(2, '|').collect();
-                if parts.len() == 2 {
-                    let _ = inject_claude_md(&project_path, parts[0], parts[1]);
-                }
-            }
-        }
-    }
 
     let entry = TerminalEntry {
         master: pty_pair.master,

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -252,10 +252,19 @@
         };
         entry.channel = onOutput;
 
+        // Get existing session IDs BEFORE spawning so we can detect the new one
+        let existingSessionIds = [];
+        if (!profile.claudeSessionId) {
+          try {
+            const existing = await invoke("discover_sessions", { projectPath: profile.projectPath });
+            existingSessionIds = existing.map(s => s.sessionId);
+          } catch(e) {}
+        }
+
         const tid = await invoke("spawn_terminal", {
           sessionId: profile.claudeSessionId || null,
           projectPath: spawnPath,
-          contextPrompt: `${profile.purpose}|${profile.title}`,
+          contextPrompt: null,
           onOutput: onOutput,
         });
         entry.terminalId = tid;
@@ -263,17 +272,29 @@
         statusMsg = profile.title;
         showTermEntry(entry);
 
+        // For new sessions: inject purpose prompt via stdin after claude starts
         if (!profile.claudeSessionId) {
+          const prompt = getPurposePrompt(profile.purpose);
+          if (prompt) {
+            setTimeout(async () => {
+              try {
+                await invoke("write_to_terminal", { terminalId: tid, data: prompt + "\n" });
+              } catch(e) {}
+            }, 3000);
+          }
+
+          // Capture the NEW session ID (not an old one)
           setTimeout(async () => {
             try {
-              const sessions = await invoke("discover_sessions", { projectPath: profile.projectPath });
-              if (sessions.length > 0) {
-                await invoke("update_session_id", { id: profile.id, claudeSessionId: sessions[0].sessionId });
-                profile.claudeSessionId = sessions[0].sessionId;
+              const allSessions = await invoke("discover_sessions", { projectPath: profile.projectPath });
+              const newSession = allSessions.find(s => !existingSessionIds.includes(s.sessionId));
+              if (newSession) {
+                await invoke("update_session_id", { id: profile.id, claudeSessionId: newSession.sessionId });
+                profile.claudeSessionId = newSession.sessionId;
                 await loadProfiles();
               }
             } catch(e) {}
-          }, 3000);
+          }, 5000);
         }
 
         entry.fitAddon.fit();
@@ -440,6 +461,17 @@
         .catch(() => {});
     }
     if (typeof localStorage !== 'undefined') localStorage.setItem('clauge-last-seen-version', version);
+  }
+
+  function getPurposePrompt(purpose) {
+    const prompts = {
+      "Brainstorming": "You are in a brainstorming session. Explore multiple approaches, ask clarifying questions, think out loud with tradeoffs and alternatives. Do NOT write code unless explicitly asked. Focus on architecture and strategy. Challenge assumptions.",
+      "Development": "You are in a development session. Write clean working code, follow existing patterns, make small focused changes one at a time. Run tests and verify before moving on. If requirements are unclear, ask.",
+      "Code Review": "You are in a code review session. Review recent changes critically. Check for bugs, security issues, performance problems, edge cases. Reference specific files and lines. Be direct.",
+      "PR Review": "You are in a PR review session. Ask which branch or PR to review. Run git diff to see all changes. Review every file. Check for bugs, security, logic errors. Summarize what the PR does, what's good, what needs fixing.",
+      "Debugging": "You are in a debugging session. Reproduce the issue first. Form a hypothesis then verify with evidence. Do NOT guess fixes. Trace the root cause methodically. Explain root cause before proposing a fix. Verify the fix works.",
+    };
+    return prompts[purpose] || null;
   }
 
   function openExternal(url) {


### PR DESCRIPTION
## Problem
- CLAUDE.md was written to the project directory — shared by all sessions. Last session's purpose overwrote all others.
- Session IDs were auto-discovered from the project directory — wrong session could get linked.
- New sessions could resume old sessions on restart.

## Fix
- **Remove CLAUDE.md injection** — purpose prompt is now sent via stdin as the first message after claude starts. Each session is independent.
- **Stop auto-discovering session IDs** — `refresh_session_ids` no longer scans the project directory. IDs are only captured when a NEW session starts, by diffing session files before/after spawn.
- **Zero Rust warnings** — removed unused functions (`inject_claude_md`, `discover_claude_session_id`)

## Test plan
- [ ] Create two sessions for same project (Dev + Debug) — each gets its own purpose prompt
- [ ] Verify one session's purpose doesn't affect the other
- [ ] Delete a session, create new one — starts fresh, no old history
- [ ] Close app, reopen — sessions resume correctly with their own IDs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changes**
  * Removed automatic session discovery functionality; session IDs now reflect only stored values.
  * Modified context prompt injection to occur after terminal starts (with a delay) rather than before initialization.
  * Updated session ID capture logic for newly spawned sessions to identify and persist the correct session identifier.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->