### PR TITLE
feat: persistent purpose prompts, session cleanup, website refresh

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@
 
 ## Session Purposes
 
-Each session runs with a specific purpose. Claude stays in that mode throughout the conversation.
+Each session stays focused on what you need right now. The purpose persists throughout the entire conversation.
 
-| Purpose | What happens |
+| Purpose | What you get |
 |---------|-------------|
-| **Brainstorming** | Explores ideas, asks questions, compares approaches. Won't jump to code until you say so. |
-| **Development** | Writes clean code, follows your codebase patterns, makes small focused changes. |
-| **Code Review** | Reviews your recent changes — finds bugs, security issues, missing edge cases. Gives specific, actionable feedback. |
-| **PR Review** | Asks for the branch, pulls the diff, and reviews the entire PR. Summarizes what changed and what needs fixing. |
-| **Debugging** | Reproduces the issue, traces the root cause step by step, verifies the fix. No guessing. |
+| **Brainstorming** | Think through architecture before writing a line of code. Get multiple approaches with tradeoffs so you pick the right one. |
+| **Development** | Ship features with clean, tested code that follows your existing patterns. Small changes, verified one at a time. |
+| **Code Review** | Catch bugs, security holes, and edge cases before they reach production. Specific feedback with file and line references. |
+| **PR Review** | Review pull requests end-to-end before merging. Clear summary of what changed, what's good, and what needs work. |
+| **Debugging** | Find the root cause, not a band-aid. Reproduces the issue, traces it methodically, and verifies the fix actually works. |
 
 ## Features
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -45,8 +45,8 @@
   <div class="container">
     <div class="section-header reveal" style="text-align:center;max-width:600px;margin:0 auto 56px;">
       <p class="section-tag">Purposes</p>
-      <h2 class="section-heading">Every session has a purpose</h2>
-      <p class="section-sub" style="max-width:100%;">Pick a mode when you create a session. Claude adapts its behavior to match — not a one-time instruction, it persists throughout.</p>
+      <h2 class="section-heading">One project, multiple workflows</h2>
+      <p class="section-sub" style="max-width:100%;">Each session stays focused on what you need right now. Start brainstorming, move to building, review before you ship.</p>
     </div>
     <div class="purposes-grid">
       <div class="purpose-card reveal" style="border-left-color: var(--purple);">
@@ -55,7 +55,7 @@
         </div>
         <div>
           <div class="purpose-name" style="color: var(--purple);">Brainstorming</div>
-          <div class="purpose-desc">Explores ideas, compares approaches, challenges assumptions. Won't jump to code until you're ready.</div>
+          <div class="purpose-desc">Think through architecture before writing a line of code. Get multiple approaches with tradeoffs so you pick the right one.</div>
         </div>
       </div>
       <div class="purpose-card reveal reveal-delay-1" style="border-left-color: var(--green);">
@@ -64,7 +64,7 @@
         </div>
         <div>
           <div class="purpose-name" style="color: var(--green);">Development</div>
-          <div class="purpose-desc">Writes clean code, follows your codebase patterns, makes focused changes one at a time.</div>
+          <div class="purpose-desc">Ship features with clean, tested code that follows your existing patterns. Small changes, verified one at a time.</div>
         </div>
       </div>
       <div class="purpose-card reveal reveal-delay-2" style="border-left-color: var(--blue);">
@@ -73,7 +73,7 @@
         </div>
         <div>
           <div class="purpose-name" style="color: var(--blue);">Code Review</div>
-          <div class="purpose-desc">Reviews your changes for bugs, security issues, and missing edge cases. Specific, actionable feedback.</div>
+          <div class="purpose-desc">Catch bugs, security holes, and edge cases before they reach production. Get specific feedback with file and line references.</div>
         </div>
       </div>
       <div class="purpose-card reveal reveal-delay-3" style="border-left-color: var(--yellow);">
@@ -82,7 +82,7 @@
         </div>
         <div>
           <div class="purpose-name" style="color: var(--yellow);">PR Review</div>
-          <div class="purpose-desc">Pulls the branch diff, reviews the entire PR, summarizes what changed and what needs fixing.</div>
+          <div class="purpose-desc">Review pull requests end-to-end before merging. Get a clear summary of what changed, what's good, and what needs work.</div>
         </div>
       </div>
       <div class="purpose-card reveal reveal-delay-4" style="border-left-color: var(--red);">
@@ -91,7 +91,7 @@
         </div>
         <div>
           <div class="purpose-name" style="color: var(--red);">Debugging</div>
-          <div class="purpose-desc">Reproduces the issue, traces the root cause step by step, verifies the fix. No guessing.</div>
+          <div class="purpose-desc">Find the root cause, not a band-aid. Reproduces the issue, traces it methodically, and verifies the fix actually works.</div>
         </div>
       </div>
     </div>

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -614,7 +614,7 @@ fn spawn_terminal(
     state: State<'_, TerminalState>,
     session_id: Option<String>,
     project_path: String,
-    _context_prompt: Option<String>,
+    context_prompt: Option<String>,
     on_output: Channel<TerminalOutputPayload>,
 ) -> Result<String, String> {
     let terminal_id = Uuid::new_v4().to_string();
@@ -632,6 +632,14 @@ fn spawn_terminal(
     let mut claude_cmd = String::from("claude");
     if let Some(ref sid) = session_id {
         claude_cmd.push_str(&format!(" --resume {}", sid));
+    }
+    // Inject purpose prompt via --append-system-prompt (persists every turn)
+    if let Some(ref prompt) = context_prompt {
+        if !prompt.is_empty() {
+            // Escape single quotes for shell
+            let escaped = prompt.replace('\'', "'\\''");
+            claude_cmd.push_str(&format!(" --append-system-prompt '{}'", escaped));
+        }
     }
 
     eprintln!("[Clauge] Spawning: /bin/zsh -l -c '{}'", claude_cmd);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -261,10 +261,13 @@
           } catch(e) {}
         }
 
+        // Pass purpose prompt — gets injected via --append-system-prompt (persists every turn)
+        const purposePrompt = getPurposePrompt(profile.purpose);
+
         const tid = await invoke("spawn_terminal", {
           sessionId: profile.claudeSessionId || null,
           projectPath: spawnPath,
-          contextPrompt: null,
+          contextPrompt: purposePrompt,
           onOutput: onOutput,
         });
         entry.terminalId = tid;
@@ -272,17 +275,7 @@
         statusMsg = profile.title;
         showTermEntry(entry);
 
-        // For new sessions: inject purpose prompt via stdin after claude starts
         if (!profile.claudeSessionId) {
-          const prompt = getPurposePrompt(profile.purpose);
-          if (prompt) {
-            setTimeout(async () => {
-              try {
-                await invoke("write_to_terminal", { terminalId: tid, data: prompt + "\n" });
-              } catch(e) {}
-            }, 3000);
-          }
-
           // Capture the NEW session ID (not an old one)
           setTimeout(async () => {
             try {
@@ -336,8 +329,22 @@
 
   async function confirmDelete() {
     if (!deleteConfirm) return;
-    await invoke("delete_profile", { id: deleteConfirm.id });
-    if (activeProfile?.id === deleteConfirm.id) { activeProfile = null; currentTerminalId = null; }
+    const deletedId = deleteConfirm.id;
+    await invoke("delete_profile", { id: deletedId });
+
+    // If deleting the active session, clean up terminal and show empty state
+    if (activeProfile?.id === deletedId) {
+      const entry = terminalMap.get(deletedId);
+      if (entry) {
+        entry.container.style.display = "none";
+        if (entry.term) entry.term.dispose();
+        terminalMap.delete(deletedId);
+      }
+      activeProfile = null;
+      activeTermEntry = null;
+      currentTerminalId = null;
+    }
+
     deleteConfirm = null;
     await loadProfiles();
   }
@@ -465,11 +472,104 @@
 
   function getPurposePrompt(purpose) {
     const prompts = {
-      "Brainstorming": "You are in a brainstorming session. Explore multiple approaches, ask clarifying questions, think out loud with tradeoffs and alternatives. Do NOT write code unless explicitly asked. Focus on architecture and strategy. Challenge assumptions.",
-      "Development": "You are in a development session. Write clean working code, follow existing patterns, make small focused changes one at a time. Run tests and verify before moving on. If requirements are unclear, ask.",
-      "Code Review": "You are in a code review session. Review recent changes critically. Check for bugs, security issues, performance problems, edge cases. Reference specific files and lines. Be direct.",
-      "PR Review": "You are in a PR review session. Ask which branch or PR to review. Run git diff to see all changes. Review every file. Check for bugs, security, logic errors. Summarize what the PR does, what's good, what needs fixing.",
-      "Debugging": "You are in a debugging session. Reproduce the issue first. Form a hypothesis then verify with evidence. Do NOT guess fixes. Trace the root cause methodically. Explain root cause before proposing a fix. Verify the fix works.",
+      "Brainstorming": `You are in a brainstorming session. Follow these rules strictly:
+
+HARD RULE: Do NOT write implementation code unless the user explicitly asks for it.
+
+Your process:
+1. Understand the problem — ask clarifying questions before proposing solutions
+2. Explore 2-3 different approaches with tradeoffs for each
+3. Think out loud — share risks, assumptions, and alternatives
+4. Challenge the user's assumptions if something seems off
+5. Summarize with pros/cons before the user decides
+6. Only move to implementation details when the user picks a direction
+
+Anti-patterns to avoid:
+- Jumping to code when the user is still exploring
+- Proposing only one approach
+- Agreeing with everything without pushback`,
+
+      "Development": `You are in a development session. Follow these rules strictly:
+
+Your process:
+1. Understand what needs to change before touching code
+2. Read existing code first — follow the patterns already in the codebase
+3. Make small, focused changes — one thing at a time
+4. Verify each change works before moving to the next
+5. If requirements are unclear, ask — do not guess
+
+Quality gates:
+- Does this change follow existing conventions?
+- Are error cases handled?
+- Would this break anything else?
+- Is this the simplest solution that works?
+
+Anti-patterns to avoid:
+- Rewriting large sections when a small edit works
+- Adding features that weren't asked for
+- Skipping verification after changes`,
+
+      "Code Review": `You are in a code review session. Follow these rules strictly:
+
+Your process:
+1. Read all recent changes systematically — do not skip files
+2. For each change, check: bugs, security issues, performance, edge cases
+3. Reference specific files and line numbers
+4. Suggest concrete fixes, not vague advice
+5. Flag anything that could break in production
+
+What to check:
+- Error handling — are failures handled gracefully?
+- Security — input validation, auth checks, injection risks
+- Edge cases — null values, empty arrays, concurrent access
+- Missing tests — is new behavior tested?
+
+Anti-patterns to avoid:
+- Nitpicking style when there are real bugs
+- Being vague ("this could be better")
+- Missing the forest for the trees`,
+
+      "PR Review": `You are in a PR review session. Follow these rules strictly:
+
+Your process:
+1. Ask which branch or PR to review
+2. Run git diff main...<branch> to see all changes
+3. Review every changed file — do not skip any
+4. Summarize: what the PR does, what's good, what needs fixing
+5. Give a clear verdict: approve, request changes, or needs discussion
+
+What to check:
+- Does the PR do what it claims?
+- Are there breaking changes or missing migrations?
+- Is test coverage adequate for new code?
+- Are there security implications?
+
+Anti-patterns to avoid:
+- Reviewing only part of the diff
+- Approving without thorough review
+- Mixing style feedback with functional issues`,
+
+      "Debugging": `You are in a debugging session. Follow these rules strictly:
+
+HARD RULE: Do NOT guess fixes. Trace the root cause first.
+
+Your process — follow these phases in order:
+1. REPRODUCE — Confirm the symptoms. If you can't reproduce, gather more information
+2. HYPOTHESIZE — Form a specific hypothesis about the cause
+3. VERIFY — Test the hypothesis with evidence (logs, output, traces). If wrong, go back to step 2
+4. ROOT CAUSE — Explain exactly why the bug happens before proposing any fix
+5. FIX — Make the minimal change that addresses the root cause
+6. VERIFY FIX — Confirm the original issue is resolved and no new issues introduced
+
+Red flags that you're doing it wrong:
+- Trying random fixes without understanding the cause
+- Each fix reveals a new problem in a different place (architectural issue)
+- Unable to explain WHY the bug happens
+
+Anti-patterns to avoid:
+- Applying fixes before understanding root cause
+- Changing multiple things at once
+- Ignoring related symptoms`,
     };
     return prompts[purpose] || null;
   }


### PR DESCRIPTION
## Summary
- Purpose injected via `claude --append-system-prompt` — persists every turn, per-session, no shared files
- Richer prompts with hard rules, process steps, anti-patterns
- Remove CLAUDE.md and stdin injection entirely
- Delete session cleans up terminal and shows empty state
- Website + README purpose descriptions focus on user benefits

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated session purpose descriptions in README and web documentation with clearer emphasis on outcomes for each workflow type (brainstorm → build → review).

* **Improvements**
  * Enhanced purpose prompts with more detailed guidance and structured instructions.
  * Improved session deletion to properly clean up associated terminals and application state.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->