### PR TITLE
feat: consolidate usage detail into Settings > Usage tab

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,12 @@
 
 ---
 
+<p align="center">
+  <video src="docs/promo.mp4" autoplay loop muted playsinline width="800"></video>
+</p>
+
+---
+
 ## Session Purposes
 
 Each session stays focused on what you need right now. The purpose persists throughout the entire conversation.
@@ -41,7 +47,7 @@ Each session stays focused on what you need right now. The purpose persists thro
 
 **Embedded terminal** — Full interactive terminal built in. Colors, scrollback, resize. Switch between sessions instantly without re-spawning Claude.
 
-**~10MB, low resource usage** — Built with Rust and Tauri. No Electron, no bundled Chromium. Starts fast, stays light.
+**~7MB, low resource usage** — Built with Rust and Tauri. No Electron, no bundled Chromium. Starts fast, stays light.
 
 **Organized by project** — Sessions grouped by project folder with expand/collapse. Auto-discovers your existing Claude Code sessions.
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -1,490 +1,1024 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Clauge — Run multiple Claude Code sessions in parallel</title>
-  <meta name="description" content="Organize, label, and resume Claude Code sessions from a lightweight macOS app. Purpose-driven workflows, embedded terminal, automatic session isolation.">
-  <link rel="stylesheet" href="style.css">
-  <link rel="icon" href="icon.svg">
-</head>
-<body>
-
-<!-- Header -->
-<header id="header">
-  <div class="inner">
-    <a href="#" class="logo">Clauge</a>
-    <div class="header-right">
-      <a href="changelog.html" class="header-link">Changelog</a>
-      <a href="https://github.com/ansxuman/Clauge" class="gh-link">
-        <svg viewBox="0 0 16 16"><path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"/></svg>
-        GitHub
-      </a>
-    </div>
-  </div>
-</header>
-
-<!-- Hero -->
-<section class="hero">
-  <div class="container">
-    <h1 class="reveal">Run multiple Claude Code<br>sessions <span class="hero-typewriter"></span></h1>
-    <p class="subtitle reveal reveal-delay-1">Organized by project, each with its own purpose and terminal.<br>Built with Rust + Tauri.</p>
-    <div class="hero-buttons reveal reveal-delay-2">
-      <a id="hero-download" href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
-        <svg viewBox="0 0 16 16" fill="currentColor"><path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"/></svg>
-        <span class="dl-text">Download for macOS</span>
-      </a>
-      <a href="https://github.com/ansxuman/Clauge" class="btn-secondary">View on GitHub</a>
-    </div>
-    <p class="hero-meta reveal reveal-delay-3">macOS only &middot; ~10MB &middot; Apache 2.0</p>
-  </div>
-</section>
-
-<!-- Purposes -->
-<section class="purposes-section">
-  <div class="container">
-    <div class="section-header reveal" style="text-align:center;max-width:600px;margin:0 auto 56px;">
-      <p class="section-tag">Purposes</p>
-      <h2 class="section-heading">One project, multiple workflows</h2>
-      <p class="section-sub" style="max-width:100%;">Each session stays focused on what you need right now. Start brainstorming, move to building, review before you ship.</p>
-    </div>
-    <div class="purposes-grid">
-      <div class="purpose-card reveal" style="border-left-color: var(--purple);">
-        <div class="purpose-icon" style="color:var(--purple);">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="12" cy="12" r="10"/><path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3"/><line x1="12" y1="17" x2="12.01" y2="17"/></svg>
-        </div>
-        <div>
-          <div class="purpose-name" style="color: var(--purple);">Brainstorming</div>
-          <div class="purpose-desc">Think through architecture before writing a line of code. Get multiple approaches with tradeoffs so you pick the right one.</div>
-        </div>
-      </div>
-      <div class="purpose-card reveal reveal-delay-1" style="border-left-color: var(--green);">
-        <div class="purpose-icon" style="color:var(--green);">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><polyline points="16 18 22 12 16 6"/><polyline points="8 6 2 12 8 18"/></svg>
-        </div>
-        <div>
-          <div class="purpose-name" style="color: var(--green);">Development</div>
-          <div class="purpose-desc">Ship features with clean, tested code that follows your existing patterns. Small changes, verified one at a time.</div>
-        </div>
-      </div>
-      <div class="purpose-card reveal reveal-delay-2" style="border-left-color: var(--blue);">
-        <div class="purpose-icon" style="color:var(--blue);">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
-        </div>
-        <div>
-          <div class="purpose-name" style="color: var(--blue);">Code Review</div>
-          <div class="purpose-desc">Catch bugs, security holes, and edge cases before they reach production. Get specific feedback with file and line references.</div>
-        </div>
-      </div>
-      <div class="purpose-card reveal reveal-delay-3" style="border-left-color: var(--yellow);">
-        <div class="purpose-icon" style="color:var(--yellow);">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="18" cy="18" r="3"/><circle cx="6" cy="6" r="3"/><path d="M13 6h3a2 2 0 012 2v7"/><path d="M11 18H8a2 2 0 01-2-2V9"/></svg>
-        </div>
-        <div>
-          <div class="purpose-name" style="color: var(--yellow);">PR Review</div>
-          <div class="purpose-desc">Review pull requests end-to-end before merging. Get a clear summary of what changed, what's good, and what needs work.</div>
-        </div>
-      </div>
-      <div class="purpose-card reveal reveal-delay-4" style="border-left-color: var(--red);">
-        <div class="purpose-icon" style="color:var(--red);">
-          <svg width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M18.36 6.64A9 9 0 115.64 18.36"/><line x1="12" y1="2" x2="12" y2="6"/><line x1="12" y1="18" x2="12" y2="22"/></svg>
-        </div>
-        <div>
-          <div class="purpose-name" style="color: var(--red);">Debugging</div>
-          <div class="purpose-desc">Find the root cause, not a band-aid. Reproduces the issue, traces it methodically, and verifies the fix actually works.</div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
-
-<!-- Features -->
-<section class="features-section">
-  <div class="container">
-    <div class="section-header reveal">
-      <p class="section-tag">Features</p>
-      <h2 class="section-heading">What you get</h2>
-    </div>
-
-    <!-- Feature 1: Sidebar + terminal with session switching -->
-    <div class="feature-row reveal">
-      <div class="feature-text">
-        <h3>Parallel sessions, zero conflicts</h3>
-        <p>Run multiple sessions on the same project. Each one is automatically isolated — edit files in one without breaking the other. Switch between them instantly.</p>
-      </div>
-      <div class="feature-visual">
-        <div class="demo-app">
-          <div class="demo-app-bar"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span></div>
-          <div class="demo-app-body">
-            <div class="demo-sidebar">
-              <div class="demo-side-hdr">Clauge <span class="demo-side-plus">+</span></div>
-              <div class="demo-side-group">
-                <div class="demo-side-grp-hdr"><span class="demo-chevron">&#9656;</span> MYAPP <span class="demo-grp-count">3</span></div>
-                <div class="demo-side-item active" data-idx="0">
-                  <span class="demo-status-dot on"></span>
-                  Auth refactor
-                  <span class="demo-side-badge dev">Dev</span>
+    <head>
+        <meta charset="UTF-8" />
+        <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+        <title>Clauge — Run multiple Claude Code sessions in parallel</title>
+        <meta
+            name="description"
+            content="Organize, label, and resume Claude Code sessions from a lightweight macOS app. Purpose-driven workflows, embedded terminal, automatic session isolation."
+        />
+        <link rel="stylesheet" href="style.css" />
+        <link rel="icon" href="icon.svg" />
+    </head>
+    <body>
+        <!-- Header -->
+        <header id="header">
+            <div class="inner">
+                <a href="#" class="logo">Clauge</a>
+                <div class="header-right">
+                    <a href="changelog.html" class="header-link">Changelog</a>
+                    <a
+                        href="https://github.com/ansxuman/Clauge"
+                        class="gh-link"
+                    >
+                        <svg viewBox="0 0 16 16">
+                            <path
+                                d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                            />
+                        </svg>
+                        GitHub
+                    </a>
                 </div>
-                <div class="demo-side-item" data-idx="1">
-                  <span class="demo-status-dot"></span>
-                  API endpoints
-                  <span class="demo-side-badge review">Review</span>
+            </div>
+        </header>
+
+        <!-- Hero -->
+        <section class="hero">
+            <div class="container hero-split">
+                <div class="hero-left">
+                    <h1 class="reveal">
+                        Run multiple Claude Code<br />sessions
+                        <span class="hero-typewriter"></span>
+                    </h1>
+                    <p class="subtitle reveal reveal-delay-1">
+                        Organized by project, each with its own purpose and
+                        terminal.<br />Built with Rust + Tauri.
+                    </p>
+                    <div class="hero-buttons reveal reveal-delay-2">
+                        <a
+                            id="hero-download"
+                            href="https://github.com/ansxuman/Clauge/releases/latest"
+                            class="btn-primary"
+                        >
+                            <svg viewBox="0 0 16 16" fill="currentColor">
+                                <path
+                                    d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"
+                                />
+                            </svg>
+                            <span class="dl-text">Download for macOS</span>
+                        </a>
+                        <a
+                            href="https://github.com/ansxuman/Clauge"
+                            class="btn-secondary"
+                        >
+                            <svg
+                                width="16"
+                                height="16"
+                                viewBox="0 0 16 16"
+                                fill="currentColor"
+                            >
+                                <path
+                                    d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z"
+                                />
+                            </svg>
+                            View on GitHub
+                        </a>
+                    </div>
+                    <p class="hero-meta reveal reveal-delay-3">
+                        macOS only &middot; ~7MB &middot; Apache 2.0
+                    </p>
                 </div>
-                <div class="demo-side-item" data-idx="2">
-                  <span class="demo-status-dot"></span>
-                  Bug #42
-                  <span class="demo-side-badge debug">Debug</span>
-                  <span class="demo-side-wt">WT</span>
+                <div class="hero-right reveal reveal-delay-1">
+                    <div class="hero-video-wrap">
+                        <video
+                            class="promo-video"
+                            autoplay
+                            loop
+                            muted
+                            playsinline
+                        >
+                            <source src="promo.mp4" type="video/mp4" />
+                        </video>
+                    </div>
                 </div>
-              </div>
-              <div class="demo-side-group">
-                <div class="demo-side-grp-hdr"><span class="demo-chevron">&#9656;</span> BACKEND <span class="demo-grp-count">2</span></div>
-                <div class="demo-side-item" data-idx="3">
-                  <span class="demo-status-dot"></span>
-                  PR #87
-                  <span class="demo-side-badge pr">PR</span>
+            </div>
+        </section>
+
+        <!-- Purposes -->
+        <section class="purposes-section">
+            <div class="container">
+                <div
+                    class="section-header reveal"
+                    style="
+                        text-align: center;
+                        max-width: 600px;
+                        margin: 0 auto 56px;
+                    "
+                >
+                    <p class="section-tag">Purposes</p>
+                    <h2 class="section-heading">
+                        One project, multiple workflows
+                    </h2>
+                    <p class="section-sub" style="max-width: 100%">
+                        Each session stays focused on what you need right now.
+                        Start brainstorming, move to building, review before you
+                        ship.
+                    </p>
                 </div>
-                <div class="demo-side-item" data-idx="4">
-                  <span class="demo-status-dot"></span>
-                  Brainstorm DB
-                  <span class="demo-side-badge brain">Brain</span>
+                <div class="purposes-grid">
+                    <div
+                        class="purpose-card reveal"
+                        style="border-left-color: var(--purple)"
+                    >
+                        <div class="purpose-icon" style="color: var(--purple)">
+                            <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            >
+                                <circle cx="12" cy="12" r="10" />
+                                <path d="M9.09 9a3 3 0 015.83 1c0 2-3 3-3 3" />
+                                <line x1="12" y1="17" x2="12.01" y2="17" />
+                            </svg>
+                        </div>
+                        <div>
+                            <div
+                                class="purpose-name"
+                                style="color: var(--purple)"
+                            >
+                                Brainstorming
+                            </div>
+                            <div class="purpose-desc">
+                                Think through architecture before writing a line
+                                of code. Get multiple approaches with tradeoffs
+                                so you pick the right one.
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="purpose-card reveal reveal-delay-1"
+                        style="border-left-color: var(--green)"
+                    >
+                        <div class="purpose-icon" style="color: var(--green)">
+                            <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            >
+                                <polyline points="16 18 22 12 16 6" />
+                                <polyline points="8 6 2 12 8 18" />
+                            </svg>
+                        </div>
+                        <div>
+                            <div
+                                class="purpose-name"
+                                style="color: var(--green)"
+                            >
+                                Development
+                            </div>
+                            <div class="purpose-desc">
+                                Ship features with clean, tested code that
+                                follows your existing patterns. Small changes,
+                                verified one at a time.
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="purpose-card reveal reveal-delay-2"
+                        style="border-left-color: var(--blue)"
+                    >
+                        <div class="purpose-icon" style="color: var(--blue)">
+                            <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            >
+                                <path
+                                    d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"
+                                />
+                                <circle cx="12" cy="12" r="3" />
+                            </svg>
+                        </div>
+                        <div>
+                            <div
+                                class="purpose-name"
+                                style="color: var(--blue)"
+                            >
+                                Code Review
+                            </div>
+                            <div class="purpose-desc">
+                                Catch bugs, security holes, and edge cases
+                                before they reach production. Get specific
+                                feedback with file and line references.
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="purpose-card reveal reveal-delay-3"
+                        style="border-left-color: var(--yellow)"
+                    >
+                        <div class="purpose-icon" style="color: var(--yellow)">
+                            <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            >
+                                <circle cx="18" cy="18" r="3" />
+                                <circle cx="6" cy="6" r="3" />
+                                <path d="M13 6h3a2 2 0 012 2v7" />
+                                <path d="M11 18H8a2 2 0 01-2-2V9" />
+                            </svg>
+                        </div>
+                        <div>
+                            <div
+                                class="purpose-name"
+                                style="color: var(--yellow)"
+                            >
+                                PR Review
+                            </div>
+                            <div class="purpose-desc">
+                                Review pull requests end-to-end before merging.
+                                Get a clear summary of what changed, what's
+                                good, and what needs work.
+                            </div>
+                        </div>
+                    </div>
+                    <div
+                        class="purpose-card reveal reveal-delay-4"
+                        style="border-left-color: var(--red)"
+                    >
+                        <div class="purpose-icon" style="color: var(--red)">
+                            <svg
+                                width="20"
+                                height="20"
+                                viewBox="0 0 24 24"
+                                fill="none"
+                                stroke="currentColor"
+                                stroke-width="2"
+                            >
+                                <path d="M18.36 6.64A9 9 0 115.64 18.36" />
+                                <line x1="12" y1="2" x2="12" y2="6" />
+                                <line x1="12" y1="18" x2="12" y2="22" />
+                            </svg>
+                        </div>
+                        <div>
+                            <div class="purpose-name" style="color: var(--red)">
+                                Debugging
+                            </div>
+                            <div class="purpose-desc">
+                                Find the root cause, not a band-aid. Reproduces
+                                the issue, traces it methodically, and verifies
+                                the fix actually works.
+                            </div>
+                        </div>
+                    </div>
                 </div>
-              </div>
             </div>
-            <div class="demo-terminal-pane">
-              <div class="demo-term-content active" data-panel="0">
-                <span class="demo-prompt">&#10095;</span> Refactoring auth middleware to use JWT<br>
-                <span class="demo-dim">Reading src/middleware/auth.ts</span><br>
-                <span class="demo-dim">Reading src/utils/jwt.ts</span><br><br>
-                I'll update the middleware to validate tokens...<span class="demo-cursor"></span>
-              </div>
-              <div class="demo-term-content" data-panel="1">
-                <span class="demo-prompt">&#10095;</span> Review the API endpoints for security<br>
-                <span class="demo-dim">Found 2 issues in routes/users.ts</span><br><br>
-                Missing rate limiting on POST /api/auth/login...<span class="demo-cursor"></span>
-              </div>
-              <div class="demo-term-content" data-panel="2">
-                <span class="demo-prompt">&#10095;</span> Token expires after 5 minutes<br>
-                <span class="demo-dim">Checking refresh logic...</span><br><br>
-                Root cause: interval set to 300s not 3600s<span class="demo-cursor"></span>
-              </div>
-              <div class="demo-term-content" data-panel="3">
-                <span class="demo-prompt">&#10095;</span> Reviewing PR #87 — DB connection pooling<br>
-                <span class="demo-dim">git diff main...feat/db-pool</span><br><br>
-                Changes look good. One concern with max_connections...<span class="demo-cursor"></span>
-              </div>
-              <div class="demo-term-content" data-panel="4">
-                <span class="demo-prompt">&#10095;</span> Should we use Redis or Memcached?<br><br>
-                Let's compare both approaches...<span class="demo-cursor"></span>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
+        </section>
 
-    <!-- Feature 2: Auto-typing terminal -->
-    <div class="feature-row reverse reveal">
-      <div class="feature-text">
-        <h3>Everything in one window</h3>
-        <p>Embedded interactive terminal with full color, scrollback, and resize. Sessions grouped by project with expand/collapse. No jumping between terminal tabs.</p>
-      </div>
-      <div class="feature-visual">
-        <div class="demo-terminal">
-          <div class="demo-term-bar"><span class="dot-r"></span><span class="dot-y"></span><span class="dot-g"></span><span class="demo-term-title">Clauge — Development</span></div>
-          <div class="demo-term-body" id="typing-terminal"></div>
-        </div>
-      </div>
-    </div>
+        <!-- Features -->
+        <section class="features-section">
+            <div class="container">
+                <div class="section-header reveal">
+                    <p class="section-tag">Features</p>
+                    <h2 class="section-heading">What you get</h2>
+                </div>
 
-    <!-- Feature 3: Morphing theme window -->
-    <div class="feature-row reveal">
-      <div class="feature-text">
-        <h3>Make it yours</h3>
-        <p>Dark and light themes. Six accent colors. Translucent sidebar. Adapts to how you work — not the other way around.</p>
-      </div>
-      <div class="feature-visual">
-        <div class="demo-theme" id="theme-demo">
-          <div class="demo-theme-window">
-            <div class="demo-theme-sidebar">
-              <div class="demo-theme-item active">Auth refactor</div>
-              <div class="demo-theme-item">Bug #42</div>
-            </div>
-            <div class="demo-theme-content">
-              <div class="demo-theme-line w80"></div>
-              <div class="demo-theme-line w60"></div>
-              <div class="demo-theme-line w90"></div>
-              <div class="demo-theme-line w40"></div>
-            </div>
-          </div>
-          <div class="demo-theme-dots">
-            <span class="theme-dot" style="--c:#58a6ff" data-accent="#58a6ff"></span>
-            <span class="theme-dot" style="--c:#d2a8ff" data-accent="#d2a8ff"></span>
-            <span class="theme-dot" style="--c:#3fb950" data-accent="#3fb950"></span>
-            <span class="theme-dot" style="--c:#f85149" data-accent="#f85149"></span>
-            <span class="theme-dot" style="--c:#d29922" data-accent="#d29922"></span>
-            <span class="theme-dot" style="--c:#ff7b72" data-accent="#ff7b72"></span>
-          </div>
-        </div>
-      </div>
-    </div>
+                <!-- Feature 1: Sidebar + terminal with session switching -->
+                <div class="feature-row reveal">
+                    <div class="feature-text">
+                        <h3>Parallel sessions, zero conflicts</h3>
+                        <p>
+                            Run multiple sessions on the same project. Each one
+                            is automatically isolated — edit files in one
+                            without breaking the other. Switch between them
+                            instantly.
+                        </p>
+                    </div>
+                    <div class="feature-visual">
+                        <div class="demo-app">
+                            <div class="demo-app-bar">
+                                <span class="dot-r"></span
+                                ><span class="dot-y"></span
+                                ><span class="dot-g"></span>
+                            </div>
+                            <div class="demo-app-body">
+                                <div class="demo-sidebar">
+                                    <div class="demo-side-hdr">
+                                        Clauge
+                                        <span class="demo-side-plus">+</span>
+                                    </div>
+                                    <div class="demo-side-group">
+                                        <div class="demo-side-grp-hdr">
+                                            <span class="demo-chevron"
+                                                >&#9656;</span
+                                            >
+                                            MYAPP
+                                            <span class="demo-grp-count"
+                                                >3</span
+                                            >
+                                        </div>
+                                        <div
+                                            class="demo-side-item active"
+                                            data-idx="0"
+                                        >
+                                            <span
+                                                class="demo-status-dot on"
+                                            ></span>
+                                            Auth refactor
+                                            <span class="demo-side-badge dev"
+                                                >Dev</span
+                                            >
+                                        </div>
+                                        <div
+                                            class="demo-side-item"
+                                            data-idx="1"
+                                        >
+                                            <span
+                                                class="demo-status-dot"
+                                            ></span>
+                                            API endpoints
+                                            <span class="demo-side-badge review"
+                                                >Review</span
+                                            >
+                                        </div>
+                                        <div
+                                            class="demo-side-item"
+                                            data-idx="2"
+                                        >
+                                            <span
+                                                class="demo-status-dot"
+                                            ></span>
+                                            Bug #42
+                                            <span class="demo-side-badge debug"
+                                                >Debug</span
+                                            >
+                                            <span class="demo-side-wt">WT</span>
+                                        </div>
+                                    </div>
+                                    <div class="demo-side-group">
+                                        <div class="demo-side-grp-hdr">
+                                            <span class="demo-chevron"
+                                                >&#9656;</span
+                                            >
+                                            BACKEND
+                                            <span class="demo-grp-count"
+                                                >2</span
+                                            >
+                                        </div>
+                                        <div
+                                            class="demo-side-item"
+                                            data-idx="3"
+                                        >
+                                            <span
+                                                class="demo-status-dot"
+                                            ></span>
+                                            PR #87
+                                            <span class="demo-side-badge pr"
+                                                >PR</span
+                                            >
+                                        </div>
+                                        <div
+                                            class="demo-side-item"
+                                            data-idx="4"
+                                        >
+                                            <span
+                                                class="demo-status-dot"
+                                            ></span>
+                                            Brainstorm DB
+                                            <span class="demo-side-badge brain"
+                                                >Brain</span
+                                            >
+                                        </div>
+                                    </div>
+                                </div>
+                                <div class="demo-terminal-pane">
+                                    <div
+                                        class="demo-term-content active"
+                                        data-panel="0"
+                                    >
+                                        <span class="demo-prompt"
+                                            >&#10095;</span
+                                        >
+                                        Refactoring auth middleware to use
+                                        JWT<br />
+                                        <span class="demo-dim"
+                                            >Reading
+                                            src/middleware/auth.ts</span
+                                        ><br />
+                                        <span class="demo-dim"
+                                            >Reading src/utils/jwt.ts</span
+                                        ><br /><br />
+                                        I'll update the middleware to validate
+                                        tokens...<span
+                                            class="demo-cursor"
+                                        ></span>
+                                    </div>
+                                    <div
+                                        class="demo-term-content"
+                                        data-panel="1"
+                                    >
+                                        <span class="demo-prompt"
+                                            >&#10095;</span
+                                        >
+                                        Review the API endpoints for security<br />
+                                        <span class="demo-dim"
+                                            >Found 2 issues in
+                                            routes/users.ts</span
+                                        ><br /><br />
+                                        Missing rate limiting on POST
+                                        /api/auth/login...<span
+                                            class="demo-cursor"
+                                        ></span>
+                                    </div>
+                                    <div
+                                        class="demo-term-content"
+                                        data-panel="2"
+                                    >
+                                        <span class="demo-prompt"
+                                            >&#10095;</span
+                                        >
+                                        Token expires after 5 minutes<br />
+                                        <span class="demo-dim"
+                                            >Checking refresh logic...</span
+                                        ><br /><br />
+                                        Root cause: interval set to 300s not
+                                        3600s<span class="demo-cursor"></span>
+                                    </div>
+                                    <div
+                                        class="demo-term-content"
+                                        data-panel="3"
+                                    >
+                                        <span class="demo-prompt"
+                                            >&#10095;</span
+                                        >
+                                        Reviewing PR #87 — DB connection
+                                        pooling<br />
+                                        <span class="demo-dim"
+                                            >git diff main...feat/db-pool</span
+                                        ><br /><br />
+                                        Changes look good. One concern with
+                                        max_connections...<span
+                                            class="demo-cursor"
+                                        ></span>
+                                    </div>
+                                    <div
+                                        class="demo-term-content"
+                                        data-panel="4"
+                                    >
+                                        <span class="demo-prompt"
+                                            >&#10095;</span
+                                        >
+                                        Should we use Redis or Memcached?<br /><br />
+                                        Let's compare both approaches...<span
+                                            class="demo-cursor"
+                                        ></span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-    <!-- Feature 4: Usage tracking — keep original clean design -->
-    <div class="feature-row reverse reveal">
-      <div class="feature-text">
-        <h3>Usage tracking</h3>
-        <p>Session and weekly usage limits visible right in the menu bar. Know how much headroom you have without opening a browser.</p>
-      </div>
-      <div class="feature-visual">
-        <div class="mockup glass-mockup">
-          <div class="mockup-titlebar">
-            <span class="mockup-dot" style="background:#ff5f57"></span><span class="mockup-dot" style="background:#febc2e"></span><span class="mockup-dot" style="background:#28c840"></span>
-          </div>
-          <div class="mockup-body mockup-usage">
-            <div class="usage-meter">
-              <span class="usage-label">Session</span>
-              <div class="usage-track"><div class="usage-fill" style="width:13%;background:var(--blue);"></div></div>
-              <span class="usage-pct">13%</span>
-            </div>
-            <div class="usage-meter">
-              <span class="usage-label">Weekly</span>
-              <div class="usage-track"><div class="usage-fill" style="width:6%;background:var(--blue);"></div></div>
-              <span class="usage-pct">6%</span>
-            </div>
-            <div class="usage-meter">
-              <span class="usage-label">Sonnet</span>
-              <div class="usage-track"><div class="usage-fill" style="width:29%;background:var(--yellow);"></div></div>
-              <span class="usage-pct">29%</span>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
-</section>
+                <!-- Feature 2: Auto-typing terminal -->
+                <div class="feature-row reverse reveal">
+                    <div class="feature-text">
+                        <h3>Everything in one window</h3>
+                        <p>
+                            Embedded interactive terminal with full color,
+                            scrollback, and resize. Sessions grouped by project
+                            with expand/collapse. No jumping between terminal
+                            tabs.
+                        </p>
+                    </div>
+                    <div class="feature-visual">
+                        <div class="demo-terminal">
+                            <div class="demo-term-bar">
+                                <span class="dot-r"></span
+                                ><span class="dot-y"></span
+                                ><span class="dot-g"></span
+                                ><span class="demo-term-title"
+                                    >Clauge — Development</span
+                                >
+                            </div>
+                            <div
+                                class="demo-term-body"
+                                id="typing-terminal"
+                            ></div>
+                        </div>
+                    </div>
+                </div>
 
-<!-- Shortcuts -->
-<section class="shortcuts-section">
-  <div class="container">
-    <div class="section-header reveal">
-      <p class="section-tag">Shortcuts</p>
-      <h2 class="section-heading">Keyboard-first</h2>
-    </div>
-    <div class="shortcuts-grid">
-      <div class="shortcut-card reveal">
-        <div class="shortcut-keys"><kbd>&#8984;</kbd> <kbd>N</kbd></div>
-        <div class="shortcut-desc">New session</div>
-      </div>
-      <div class="shortcut-card reveal reveal-delay-1">
-        <div class="shortcut-keys"><kbd>&#8984;</kbd> <kbd>1-9</kbd></div>
-        <div class="shortcut-desc">Switch session</div>
-      </div>
-      <div class="shortcut-card reveal reveal-delay-2">
-        <div class="shortcut-keys"><kbd>&#8984;</kbd> <kbd>B</kbd></div>
-        <div class="shortcut-desc">Toggle sidebar</div>
-      </div>
-      <div class="shortcut-card reveal reveal-delay-3">
-        <div class="shortcut-keys"><kbd>Esc</kbd></div>
-        <div class="shortcut-desc">Close modal</div>
-      </div>
-    </div>
-  </div>
-</section>
+                <!-- Feature 3: Morphing theme window -->
+                <div class="feature-row reveal">
+                    <div class="feature-text">
+                        <h3>Make it yours</h3>
+                        <p>
+                            Dark and light themes. Six accent colors.
+                            Translucent sidebar. Adapts to how you work — not
+                            the other way around.
+                        </p>
+                    </div>
+                    <div class="feature-visual">
+                        <div class="demo-theme" id="theme-demo">
+                            <div class="demo-theme-window">
+                                <div class="demo-theme-sidebar">
+                                    <div class="demo-theme-item active">
+                                        Auth refactor
+                                    </div>
+                                    <div class="demo-theme-item">Bug #42</div>
+                                </div>
+                                <div class="demo-theme-content">
+                                    <div class="demo-theme-line w80"></div>
+                                    <div class="demo-theme-line w60"></div>
+                                    <div class="demo-theme-line w90"></div>
+                                    <div class="demo-theme-line w40"></div>
+                                </div>
+                            </div>
+                            <div class="demo-theme-dots">
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #58a6ff"
+                                    data-accent="#58a6ff"
+                                ></span>
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #d2a8ff"
+                                    data-accent="#d2a8ff"
+                                ></span>
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #3fb950"
+                                    data-accent="#3fb950"
+                                ></span>
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #f85149"
+                                    data-accent="#f85149"
+                                ></span>
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #d29922"
+                                    data-accent="#d29922"
+                                ></span>
+                                <span
+                                    class="theme-dot"
+                                    style="--c: #ff7b72"
+                                    data-accent="#ff7b72"
+                                ></span>
+                            </div>
+                        </div>
+                    </div>
+                </div>
 
-<!-- Download -->
-<section class="download-section">
-  <div class="container reveal">
-    <h2>Get Clauge</h2>
-    <p class="sub">Free and open source.</p>
-    <a id="cta-download" href="https://github.com/ansxuman/Clauge/releases/latest" class="btn-primary">
-      <svg viewBox="0 0 16 16" fill="currentColor" width="16" height="16"><path d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"/></svg>
-      <span class="dl-text">Download for macOS</span>
-    </a>
-    <p class="below-btn"><a href="https://github.com/ansxuman/Clauge">View source on GitHub</a></p>
-  </div>
-</section>
+                <!-- Feature 4: Usage tracking — keep original clean design -->
+                <div class="feature-row reverse reveal">
+                    <div class="feature-text">
+                        <h3>Usage tracking</h3>
+                        <p>
+                            Session and weekly usage limits visible right in the
+                            menu bar. Know how much headroom you have without
+                            opening a browser.
+                        </p>
+                    </div>
+                    <div class="feature-visual">
+                        <div class="mockup glass-mockup">
+                            <div class="mockup-titlebar">
+                                <span
+                                    class="mockup-dot"
+                                    style="background: #ff5f57"
+                                ></span
+                                ><span
+                                    class="mockup-dot"
+                                    style="background: #febc2e"
+                                ></span
+                                ><span
+                                    class="mockup-dot"
+                                    style="background: #28c840"
+                                ></span>
+                            </div>
+                            <div class="mockup-body mockup-usage">
+                                <div class="usage-meter">
+                                    <span class="usage-label">Session</span>
+                                    <div class="usage-track">
+                                        <div
+                                            class="usage-fill"
+                                            style="
+                                                width: 13%;
+                                                background: var(--blue);
+                                            "
+                                        ></div>
+                                    </div>
+                                    <span class="usage-pct">13%</span>
+                                </div>
+                                <div class="usage-meter">
+                                    <span class="usage-label">Weekly</span>
+                                    <div class="usage-track">
+                                        <div
+                                            class="usage-fill"
+                                            style="
+                                                width: 6%;
+                                                background: var(--blue);
+                                            "
+                                        ></div>
+                                    </div>
+                                    <span class="usage-pct">6%</span>
+                                </div>
+                                <div class="usage-meter">
+                                    <span class="usage-label">Sonnet</span>
+                                    <div class="usage-track">
+                                        <div
+                                            class="usage-fill"
+                                            style="
+                                                width: 29%;
+                                                background: var(--yellow);
+                                            "
+                                        ></div>
+                                    </div>
+                                    <span class="usage-pct">29%</span>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </section>
 
-<!-- Footer -->
-<footer>
-  <div class="container">
-    <div class="footer-inner">
-      <div class="footer-left">
-        <div class="logo">Clauge</div>
-        <div class="footer-links">
-          <a href="https://github.com/ansxuman/Clauge">GitHub</a>
-          <a href="https://github.com/ansxuman/Clauge/issues">Report Bug</a>
-          <a href="https://github.com/ansxuman/Clauge/issues">Request Feature</a>
-        </div>
-      </div>
-      <div class="footer-right">
-        <a href="https://buymeacoffee.com/ansxuman">
-          <svg width="14" height="14" viewBox="0 0 24 24" fill="currentColor"><path d="M2 21.5c0 .28.22.5.5.5h15c.28 0 .5-.22.5-.5V18H2v3.5zM20 6h-1V4.5c0-.28-.22-.5-.5-.5h-15c-.28 0-.5.22-.5.5V6H2c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1.47c.41 1.74 1.7 3.15 3.37 3.72l-.34.78c-.12.28.04.5.34.5h6.32c.3 0 .46-.22.34-.5l-.34-.78c1.67-.57 2.96-1.98 3.37-3.72H18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2 4h-1V8h1v2z"/></svg>
-          Buy me a coffee
+        <!-- Shortcuts -->
+        <section class="shortcuts-section">
+            <div class="container">
+                <div class="section-header reveal">
+                    <p class="section-tag">Shortcuts</p>
+                    <h2 class="section-heading">Keyboard-first</h2>
+                </div>
+                <div class="shortcuts-grid">
+                    <div class="shortcut-card reveal">
+                        <div class="shortcut-keys">
+                            <kbd>&#8984;</kbd> <kbd>N</kbd>
+                        </div>
+                        <div class="shortcut-desc">New session</div>
+                    </div>
+                    <div class="shortcut-card reveal reveal-delay-1">
+                        <div class="shortcut-keys">
+                            <kbd>&#8984;</kbd> <kbd>1-9</kbd>
+                        </div>
+                        <div class="shortcut-desc">Switch session</div>
+                    </div>
+                    <div class="shortcut-card reveal reveal-delay-2">
+                        <div class="shortcut-keys">
+                            <kbd>&#8984;</kbd> <kbd>B</kbd>
+                        </div>
+                        <div class="shortcut-desc">Toggle sidebar</div>
+                    </div>
+                    <div class="shortcut-card reveal reveal-delay-3">
+                        <div class="shortcut-keys"><kbd>Esc</kbd></div>
+                        <div class="shortcut-desc">Close modal</div>
+                    </div>
+                </div>
+            </div>
+        </section>
+
+        <!-- Download -->
+        <section class="download-section">
+            <div class="container reveal">
+                <h2>Get Clauge</h2>
+                <p class="sub">Free and open source.</p>
+                <a
+                    id="cta-download"
+                    href="https://github.com/ansxuman/Clauge/releases/latest"
+                    class="btn-primary"
+                >
+                    <svg
+                        viewBox="0 0 16 16"
+                        fill="currentColor"
+                        width="16"
+                        height="16"
+                    >
+                        <path
+                            d="M2.75 14A1.75 1.75 0 011 12.25v-2.5a.75.75 0 011.5 0v2.5c0 .138.112.25.25.25h10.5a.25.25 0 00.25-.25v-2.5a.75.75 0 011.5 0v2.5A1.75 1.75 0 0113.25 14H2.75zM7.25 7.689V2a.75.75 0 011.5 0v5.689l1.97-1.969a.749.749 0 111.06 1.06l-3.25 3.25a.749.749 0 01-1.06 0L4.22 6.78a.749.749 0 111.06-1.06l1.97 1.969z"
+                        />
+                    </svg>
+                    <span class="dl-text">Download for macOS</span>
+                </a>
+                <p class="below-btn">
+                    <a href="https://github.com/ansxuman/Clauge"
+                        >View source on GitHub</a
+                    >
+                </p>
+            </div>
+        </section>
+
+        <!-- Footer -->
+        <footer>
+            <div class="container">
+                <div class="footer-inner">
+                    <div class="footer-left">
+                        <div class="logo">Clauge</div>
+                        <div class="footer-links">
+                            <a href="https://github.com/ansxuman/Clauge"
+                                >GitHub</a
+                            >
+                            <a href="https://github.com/ansxuman/Clauge/issues"
+                                >Report Bug</a
+                            >
+                            <a href="https://github.com/ansxuman/Clauge/issues"
+                                >Request Feature</a
+                            >
+                        </div>
+                    </div>
+                    <div class="footer-right">
+                        <a href="https://buymeacoffee.com/ansxuman">
+                            <svg
+                                width="14"
+                                height="14"
+                                viewBox="0 0 24 24"
+                                fill="currentColor"
+                            >
+                                <path
+                                    d="M2 21.5c0 .28.22.5.5.5h15c.28 0 .5-.22.5-.5V18H2v3.5zM20 6h-1V4.5c0-.28-.22-.5-.5-.5h-15c-.28 0-.5.22-.5.5V6H2c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1.47c.41 1.74 1.7 3.15 3.37 3.72l-.34.78c-.12.28.04.5.34.5h6.32c.3 0 .46-.22.34-.5l-.34-.78c1.67-.57 2.96-1.98 3.37-3.72H18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2 4h-1V8h1v2z"
+                                />
+                            </svg>
+                            Buy me a coffee
+                        </a>
+                    </div>
+                </div>
+                <div class="footer-bottom">Apache License 2.0</div>
+            </div>
+        </footer>
+
+        <script>
+            // Scroll reveal
+            const observer = new IntersectionObserver(
+                (entries) => {
+                    entries.forEach((e) => {
+                        if (e.isIntersecting) {
+                            e.target.classList.add("visible");
+                        }
+                    });
+                },
+                { threshold: 0.1, rootMargin: "0px 0px -40px 0px" },
+            );
+            document
+                .querySelectorAll(".reveal")
+                .forEach((el) => observer.observe(el));
+
+            // Hero typewriter
+            (function () {
+                const el = document.querySelector(".hero-typewriter");
+                if (!el) return;
+                const words = [
+                    "in parallel",
+                    "side by side",
+                    "without conflicts",
+                    "your way",
+                ];
+                const colors = [
+                    "var(--blue)",
+                    "var(--purple)",
+                    "var(--green)",
+                    "var(--yellow)",
+                ];
+                let wordIdx = 0,
+                    charIdx = 0,
+                    deleting = false;
+                function tick() {
+                    const word = words[wordIdx];
+                    if (!deleting) {
+                        el.textContent = word.slice(0, charIdx);
+                        el.style.color = colors[wordIdx];
+                        charIdx++;
+                        if (charIdx > word.length) {
+                            setTimeout(() => {
+                                deleting = true;
+                                tick();
+                            }, 2000);
+                            return;
+                        }
+                        setTimeout(tick, 60);
+                    } else {
+                        el.textContent = word.slice(0, charIdx);
+                        charIdx--;
+                        if (charIdx < 0) {
+                            deleting = false;
+                            charIdx = 0;
+                            wordIdx = (wordIdx + 1) % words.length;
+                            setTimeout(tick, 400);
+                            return;
+                        }
+                        setTimeout(tick, 30);
+                    }
+                }
+                setTimeout(tick, 800);
+            })();
+
+            // Header scroll
+            const header = document.getElementById("header");
+            window.addEventListener(
+                "scroll",
+                () => {
+                    header.classList.toggle("scrolled", window.scrollY > 20);
+                },
+                { passive: true },
+            );
+
+            // Direct download — detect arch and link to the right DMG
+            (async function () {
+                try {
+                    const resp = await fetch(
+                        "https://api.github.com/repos/ansxuman/Clauge/releases/latest",
+                    );
+                    if (!resp.ok) return;
+                    const release = await resp.json();
+                    const isArm =
+                        navigator.userAgent.includes("ARM") ||
+                        (navigator.platform === "MacIntel" &&
+                            navigator.maxTouchPoints > 0);
+                    const dmg =
+                        (release.assets || []).find(
+                            (a) =>
+                                a.name.endsWith(".dmg") &&
+                                (isArm
+                                    ? a.name.includes("aarch64")
+                                    : a.name.includes("x64") ||
+                                      a.name.includes("x86_64")),
+                        ) ||
+                        (release.assets || []).find((a) =>
+                            a.name.endsWith(".dmg"),
+                        );
+
+                    if (dmg) {
+                        const url = dmg.browser_download_url;
+                        const version = release.tag_name;
+                        const arch = isArm ? "Apple Silicon" : "Intel";
+                        document
+                            .querySelectorAll("#hero-download, #cta-download")
+                            .forEach((el) => {
+                                el.href = url;
+                                el.querySelector(".dl-text").textContent =
+                                    `Download ${version} (${arch})`;
+                            });
+                    }
+                } catch (e) {}
+            })();
+
+            // Session switcher — sidebar click + auto-cycle
+            (function () {
+                const items = document.querySelectorAll(".demo-side-item");
+                const panels = document.querySelectorAll(".demo-term-content");
+                let current = 0;
+                function switchTo(idx) {
+                    items.forEach((t) => {
+                        t.classList.remove("active");
+                        t.querySelector(".demo-status-dot").classList.remove(
+                            "on",
+                        );
+                    });
+                    panels.forEach((p) => p.classList.remove("active"));
+                    items[idx].classList.add("active");
+                    items[idx]
+                        .querySelector(".demo-status-dot")
+                        .classList.add("on");
+                    panels[idx].classList.add("active");
+                    current = idx;
+                }
+                items.forEach((item, i) =>
+                    item.addEventListener("click", () => switchTo(i)),
+                );
+                setInterval(() => switchTo((current + 1) % items.length), 3000);
+            })();
+
+            // Typing terminal
+            (function () {
+                const el = document.getElementById("typing-terminal");
+                if (!el) return;
+                const lines = [
+                    { text: "$ claude", cls: "prompt" },
+                    { text: "", cls: "" },
+                    { text: "Welcome back! Resuming session...", cls: "dim" },
+                    { text: "", cls: "" },
+                    {
+                        text: "> Review the auth middleware for security issues",
+                        cls: "",
+                    },
+                    { text: "", cls: "" },
+                    { text: "Reading src/middleware/auth.ts", cls: "dim" },
+                    { text: "Reading src/middleware/rateLimit.ts", cls: "dim" },
+                    { text: "", cls: "" },
+                    { text: "Found 2 issues:", cls: "" },
+                    {
+                        text: "  1. Missing rate limiting on /api/login",
+                        cls: "warn",
+                    },
+                    {
+                        text: "  2. JWT secret loaded from env without fallback",
+                        cls: "warn",
+                    },
+                ];
+                let lineIdx = 0,
+                    charIdx = 0;
+                function type() {
+                    if (lineIdx >= lines.length) {
+                        lineIdx = 0;
+                        el.innerHTML = "";
+                    }
+                    const line = lines[lineIdx];
+                    if (line.text === "") {
+                        el.innerHTML += "<br>";
+                        lineIdx++;
+                        charIdx = 0;
+                        setTimeout(type, 200);
+                    } else if (charIdx === 0) {
+                        el.innerHTML += `<span class="t-${line.cls}">`;
+                        charIdx++;
+                        setTimeout(type, 30);
+                    } else if (charIdx <= line.text.length) {
+                        const spans = el.querySelectorAll("span");
+                        const last = spans[spans.length - 1];
+                        last.textContent = line.text.slice(0, charIdx);
+                        charIdx++;
+                        setTimeout(type, lineIdx === 0 ? 60 : 20);
+                    } else {
+                        el.innerHTML += "</span><br>";
+                        lineIdx++;
+                        charIdx = 0;
+                        setTimeout(
+                            type,
+                            lineIdx < lines.length && lines[lineIdx].text === ""
+                                ? 100
+                                : 300,
+                        );
+                    }
+                }
+                // Start when visible
+                const obs = new IntersectionObserver(
+                    (entries) => {
+                        if (entries[0].isIntersecting) {
+                            obs.disconnect();
+                            type();
+                        }
+                    },
+                    { threshold: 0.3 },
+                );
+                obs.observe(el.closest(".feature-row"));
+            })();
+
+            // Theme color morphing
+            (function () {
+                const demo = document.getElementById("theme-demo");
+                if (!demo) return;
+                const dots = demo.querySelectorAll(".theme-dot");
+                const window_ = demo.querySelector(".demo-theme-window");
+                const activeItem = demo.querySelector(
+                    ".demo-theme-item.active",
+                );
+                let autoIdx = 0;
+                function setAccent(color) {
+                    window_.style.setProperty("--demo-accent", color);
+                    activeItem.style.borderLeftColor = color;
+                    activeItem.style.background = color + "18";
+                    dots.forEach((d) => d.classList.remove("active"));
+                }
+                dots.forEach((dot, i) => {
+                    dot.addEventListener("click", () => {
+                        setAccent(dot.dataset.accent);
+                        dot.classList.add("active");
+                        autoIdx = i;
+                    });
+                });
+                // Auto-cycle
+                const colors = [
+                    "#58a6ff",
+                    "#d2a8ff",
+                    "#3fb950",
+                    "#f85149",
+                    "#d29922",
+                    "#ff7b72",
+                ];
+                setInterval(() => {
+                    autoIdx = (autoIdx + 1) % colors.length;
+                    setAccent(colors[autoIdx]);
+                    dots[autoIdx].classList.add("active");
+                }, 2000);
+                dots[0].classList.add("active");
+            })();
+        </script>
+
+        <!-- Floating Buy Me a Coffee -->
+        <a
+            href="https://buymeacoffee.com/ansxuman"
+            target="_blank"
+            class="bmc-float"
+            title="Buy me a coffee"
+        >
+            <svg width="20" height="20" viewBox="0 0 24 24" fill="currentColor">
+                <path
+                    d="M2 21.5c0 .28.22.5.5.5h15c.28 0 .5-.22.5-.5V18H2v3.5zM20 6h-1V4.5c0-.28-.22-.5-.5-.5h-15c-.28 0-.5.22-.5.5V6H2c-1.1 0-2 .9-2 2v2c0 1.1.9 2 2 2h1.47c.41 1.74 1.7 3.15 3.37 3.72l-.34.78c-.12.28.04.5.34.5h6.32c.3 0 .46-.22.34-.5l-.34-.78c1.67-.57 2.96-1.98 3.37-3.72H18c1.1 0 2-.9 2-2V8c0-1.1-.9-2-2-2zm-2 4h-1V8h1v2z"
+                />
+            </svg>
+            <span>Buy me a coffee</span>
         </a>
-      </div>
-    </div>
-    <div class="footer-bottom">Apache License 2.0</div>
-  </div>
-</footer>
-
-<script>
-  // Scroll reveal
-  const observer = new IntersectionObserver((entries) => {
-    entries.forEach(e => { if (e.isIntersecting) { e.target.classList.add('visible'); } });
-  }, { threshold: 0.1, rootMargin: '0px 0px -40px 0px' });
-  document.querySelectorAll('.reveal').forEach(el => observer.observe(el));
-
-  // Hero typewriter
-  (function() {
-    const el = document.querySelector('.hero-typewriter');
-    if (!el) return;
-    const words = ['in parallel', 'side by side', 'without conflicts', 'your way'];
-    const colors = ['var(--blue)', 'var(--purple)', 'var(--green)', 'var(--yellow)'];
-    let wordIdx = 0, charIdx = 0, deleting = false;
-    function tick() {
-      const word = words[wordIdx];
-      if (!deleting) {
-        el.textContent = word.slice(0, charIdx);
-        el.style.color = colors[wordIdx];
-        charIdx++;
-        if (charIdx > word.length) { setTimeout(() => { deleting = true; tick(); }, 2000); return; }
-        setTimeout(tick, 60);
-      } else {
-        el.textContent = word.slice(0, charIdx);
-        charIdx--;
-        if (charIdx < 0) { deleting = false; charIdx = 0; wordIdx = (wordIdx + 1) % words.length; setTimeout(tick, 400); return; }
-        setTimeout(tick, 30);
-      }
-    }
-    setTimeout(tick, 800);
-  })();
-
-  // Header scroll
-  const header = document.getElementById('header');
-  window.addEventListener('scroll', () => {
-    header.classList.toggle('scrolled', window.scrollY > 20);
-  }, { passive: true });
-
-  // Direct download — detect arch and link to the right DMG
-  (async function() {
-    try {
-      const resp = await fetch('https://api.github.com/repos/ansxuman/Clauge/releases/latest');
-      if (!resp.ok) return;
-      const release = await resp.json();
-      const isArm = navigator.userAgent.includes('ARM') || navigator.platform === 'MacIntel' && navigator.maxTouchPoints > 0;
-      const dmg = (release.assets || []).find(a =>
-        a.name.endsWith('.dmg') && (isArm ? a.name.includes('aarch64') : a.name.includes('x64') || a.name.includes('x86_64'))
-      ) || (release.assets || []).find(a => a.name.endsWith('.dmg'));
-
-      if (dmg) {
-        const url = dmg.browser_download_url;
-        const version = release.tag_name;
-        const arch = isArm ? 'Apple Silicon' : 'Intel';
-        document.querySelectorAll('#hero-download, #cta-download').forEach(el => {
-          el.href = url;
-          el.querySelector('.dl-text').textContent = `Download ${version} (${arch})`;
-        });
-      }
-    } catch(e) {}
-  })();
-
-  // Session switcher — sidebar click + auto-cycle
-  (function() {
-    const items = document.querySelectorAll('.demo-side-item');
-    const panels = document.querySelectorAll('.demo-term-content');
-    let current = 0;
-    function switchTo(idx) {
-      items.forEach(t => { t.classList.remove('active'); t.querySelector('.demo-status-dot').classList.remove('on'); });
-      panels.forEach(p => p.classList.remove('active'));
-      items[idx].classList.add('active');
-      items[idx].querySelector('.demo-status-dot').classList.add('on');
-      panels[idx].classList.add('active');
-      current = idx;
-    }
-    items.forEach((item, i) => item.addEventListener('click', () => switchTo(i)));
-    setInterval(() => switchTo((current + 1) % items.length), 3000);
-  })();
-
-  // Typing terminal
-  (function() {
-    const el = document.getElementById('typing-terminal');
-    if (!el) return;
-    const lines = [
-      { text: '$ claude', cls: 'prompt' },
-      { text: '', cls: '' },
-      { text: 'Welcome back! Resuming session...', cls: 'dim' },
-      { text: '', cls: '' },
-      { text: '> Review the auth middleware for security issues', cls: '' },
-      { text: '', cls: '' },
-      { text: 'Reading src/middleware/auth.ts', cls: 'dim' },
-      { text: 'Reading src/middleware/rateLimit.ts', cls: 'dim' },
-      { text: '', cls: '' },
-      { text: 'Found 2 issues:', cls: '' },
-      { text: '  1. Missing rate limiting on /api/login', cls: 'warn' },
-      { text: '  2. JWT secret loaded from env without fallback', cls: 'warn' },
-    ];
-    let lineIdx = 0, charIdx = 0;
-    function type() {
-      if (lineIdx >= lines.length) { lineIdx = 0; el.innerHTML = ''; }
-      const line = lines[lineIdx];
-      if (line.text === '') {
-        el.innerHTML += '<br>';
-        lineIdx++; charIdx = 0;
-        setTimeout(type, 200);
-      } else if (charIdx === 0) {
-        el.innerHTML += `<span class="t-${line.cls}">`;
-        charIdx++;
-        setTimeout(type, 30);
-      } else if (charIdx <= line.text.length) {
-        const spans = el.querySelectorAll('span');
-        const last = spans[spans.length - 1];
-        last.textContent = line.text.slice(0, charIdx);
-        charIdx++;
-        setTimeout(type, lineIdx === 0 ? 60 : 20);
-      } else {
-        el.innerHTML += '</span><br>';
-        lineIdx++; charIdx = 0;
-        setTimeout(type, lineIdx < lines.length && lines[lineIdx].text === '' ? 100 : 300);
-      }
-    }
-    // Start when visible
-    const obs = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting) { obs.disconnect(); type(); }
-    }, { threshold: 0.3 });
-    obs.observe(el.closest('.feature-row'));
-  })();
-
-  // Theme color morphing
-  (function() {
-    const demo = document.getElementById('theme-demo');
-    if (!demo) return;
-    const dots = demo.querySelectorAll('.theme-dot');
-    const window_ = demo.querySelector('.demo-theme-window');
-    const activeItem = demo.querySelector('.demo-theme-item.active');
-    let autoIdx = 0;
-    function setAccent(color) {
-      window_.style.setProperty('--demo-accent', color);
-      activeItem.style.borderLeftColor = color;
-      activeItem.style.background = color + '18';
-      dots.forEach(d => d.classList.remove('active'));
-    }
-    dots.forEach((dot, i) => {
-      dot.addEventListener('click', () => {
-        setAccent(dot.dataset.accent);
-        dot.classList.add('active');
-        autoIdx = i;
-      });
-    });
-    // Auto-cycle
-    const colors = ['#58a6ff','#d2a8ff','#3fb950','#f85149','#d29922','#ff7b72'];
-    setInterval(() => {
-      autoIdx = (autoIdx + 1) % colors.length;
-      setAccent(colors[autoIdx]);
-      dots[autoIdx].classList.add('active');
-    }, 2000);
-    dots[0].classList.add('active');
-  })();
-</script>
-
-</body>
+    </body>
 </html>

--- a/docs/style.css
+++ b/docs/style.css
@@ -17,7 +17,7 @@
   --blue: #58a6ff;
   --yellow: #d29922;
   --red: #f85149;
-  --container: 1120px;
+  --container: 1280px;
   --font-display: 'Syne', sans-serif;
   --font-body: 'Inter', -apple-system, sans-serif;
   --font-mono: 'IBM Plex Mono', monospace;
@@ -124,18 +124,34 @@ header .inner {
 
 /* ─── Hero ─── */
 .hero {
-  padding: 160px 0 100px;
-  text-align: center;
+  min-height: 100vh;
+  display: flex;
+  align-items: center;
+  padding: 80px 0 40px;
+}
+.hero > .container { max-width: 100%; padding: 0 40px; }
+.hero-split {
+  display: flex;
+  align-items: center;
+  gap: 48px;
+  width: 100%;
+}
+.hero-left {
+  flex: 0 0 38%;
+  min-width: 0;
+}
+.hero-right {
+  flex: 1;
+  min-width: 0;
 }
 .hero h1 {
   font-family: var(--font-display);
-  font-size: clamp(36px, 6vw, 64px);
+  font-size: clamp(36px, 5vw, 58px);
   font-weight: 600;
   line-height: 1.1;
   letter-spacing: -1.5px;
   color: var(--white);
-  max-width: 800px;
-  margin: 0 auto 20px;
+  margin: 0 0 20px;
 }
 .hero-typewriter {
   border-right: 3px solid var(--blue);
@@ -144,19 +160,24 @@ header .inner {
 }
 @keyframes cursorBlink { 50% { border-color: transparent; } }
 .hero .subtitle {
-  font-size: clamp(15px, 2vw, 17px);
+  font-size: clamp(14px, 1.8vw, 16px);
   color: var(--text-muted);
   max-width: 520px;
-  margin: 0 auto 40px;
+  margin: 0 0 36px;
   line-height: 1.6;
   font-weight: 300;
 }
 .hero-buttons {
   display: flex;
   gap: 12px;
-  justify-content: center;
   flex-wrap: wrap;
   margin-bottom: 20px;
+}
+@media (max-width: 768px) {
+  .hero-split { flex-direction: column; gap: 40px; text-align: center; }
+  .hero-left { text-align: center; }
+  .hero-buttons { justify-content: center; }
+  .hero .subtitle { margin: 0 auto 36px; }
 }
 .btn-primary {
   display: inline-flex; align-items: center; gap: 8px;
@@ -364,6 +385,20 @@ section { padding: 100px 0; }
 }
 .section-header {
   margin-bottom: 56px;
+}
+
+/* ─── Hero Video ─── */
+.hero-video-wrap {
+  position: relative;
+  border-radius: 14px;
+  overflow: hidden;
+  border: 1px solid rgba(255,255,255,0.1);
+  box-shadow: 0 24px 80px rgba(0,0,0,0.6), 0 0 0 1px rgba(255,255,255,0.04) inset;
+}
+.promo-video {
+  display: block;
+  width: 100%;
+  height: auto;
 }
 
 /* ─── Purposes ─── */
@@ -603,6 +638,33 @@ footer {
   font-size: 12px;
   color: var(--text-dim);
 }
+
+/* ─── Floating Coffee Button ─── */
+.bmc-float {
+  position: fixed;
+  bottom: 24px;
+  right: 24px;
+  z-index: 999;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 50px;
+  color: var(--text);
+  font-family: var(--font-body);
+  font-size: 13px;
+  font-weight: 500;
+  transition: border-color 0.2s, background 0.2s, transform 0.15s;
+  box-shadow: 0 4px 20px rgba(0,0,0,0.4);
+}
+.bmc-float:hover {
+  border-color: #FFDD00;
+  background: rgba(255,221,0,0.08);
+  transform: translateY(-2px);
+}
+.bmc-float svg { color: #FFDD00; flex-shrink: 0; }
 
 /* ─── Demo: App with sidebar ─── */
 .demo-app {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -661,7 +661,8 @@ fn spawn_terminal(
     eprintln!("[Clauge] Spawning command (truncated): {}", &claude_cmd[..claude_cmd.len().min(120)]);
     eprintln!("[Clauge] CWD: {}", project_path);
 
-    let mut cmd = CommandBuilder::new("/bin/zsh");
+    let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let mut cmd = CommandBuilder::new(&user_shell);
     cmd.arg("-l");
     cmd.arg("-c");
     cmd.arg(&claude_cmd);

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -24,6 +24,7 @@
   let showWhatsNew = $state(false);
   let whatsNewBody = $state('');
   let sessionKeyConfigured = $state(false);
+  let usageError = $state('');
   let showKeyEdit = $state(false);
   let usageRefreshInterval = null;
   let sidebarCollapsed = $state(
@@ -65,7 +66,6 @@
   let deleteConfirm = $state(null); // profile to confirm delete
   let menuProfile = $state(null); // profile whose ellipsis menu is open
   let sessionActivity = $state({}); // profileId → 'active' | 'done' | null
-  let showUsageDetail = $state(false);
 
   // Theme state
   let currentTheme = $state(typeof localStorage !== 'undefined' ? (localStorage.getItem('clauge-theme') || 'dark') : 'dark');
@@ -603,12 +603,11 @@ Anti-patterns to avoid:
 
 
   async function loadUsageLimits() {
+    usageError = '';
     try {
-      // Load saved session key
       const key = await invoke("load_session_key");
       if (!key) return;
 
-      // Fetch via Rust (uses macOS native NSURLSession which bypasses Cloudflare)
       const usage = await invoke("fetch_usage_limits", { sessionKey: key });
 
       usageLimits = {
@@ -619,15 +618,25 @@ Anti-patterns to avoid:
         weeklySonnetPercent: usage.seven_day_sonnet?.utilization ?? null,
         weeklySonnetResets: usage.seven_day_sonnet?.resets_at ?? null,
       };
+      usageError = '';
 
-      // Update menu bar tray text
       const s = Math.round(usageLimits.sessionPercent);
       const w = Math.round(usageLimits.weeklyAllPercent);
       await invoke("update_tray_title", { title: `S:${s}% W:${w}%` }).catch(() => {});
     } catch(e) {
       console.error("Usage limits failed:", e);
+      const err = String(e).toLowerCase();
       usageLimits = null;
       await invoke("update_tray_title", { title: "" }).catch(() => {});
+
+      // Detect auth failures — session key expired or invalid
+      if (err.includes('permission') || err.includes('unauthorized') || err.includes('invalid') || err.includes('403') || err.includes('401')) {
+        sessionKeyConfigured = false;
+        usageError = 'Session key expired or invalid. Please reconnect.';
+        if (usageRefreshInterval) { clearInterval(usageRefreshInterval); usageRefreshInterval = null; }
+      } else {
+        usageError = 'Failed to fetch usage data. Try again.';
+      }
     }
   }
 
@@ -769,7 +778,7 @@ Anti-patterns to avoid:
       {@const sColor = usageLimits.sessionPercent > 80 ? '#f85149' : usageLimits.sessionPercent > 50 ? '#d29922' : 'var(--accent)'}
       {@const wColor = usageLimits.weeklyAllPercent > 80 ? '#f85149' : usageLimits.weeklyAllPercent > 50 ? '#d29922' : 'var(--accent)'}
       <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-      <div class="usage-chips-clickable" onclick={() => showUsageDetail = true}>
+      <div class="usage-chips-clickable" onclick={() => { showSettings = true; settingsTab = 'usage'; }}>
         <div class="usage-chip"><span class="usage-dot" style="background:{sColor};box-shadow:0 0 6px {sColor}44;"></span><span class="usage-lbl">Session</span><span class="usage-val" style="color:{sColor}">{usageLimits.sessionPercent.toFixed(0)}%</span></div>
         <div class="usage-sep"></div>
         <div class="usage-chip"><span class="usage-dot" style="background:{wColor};box-shadow:0 0 6px {wColor}44;"></span><span class="usage-lbl">Weekly</span><span class="usage-val" style="color:{wColor}">{usageLimits.weeklyAllPercent.toFixed(0)}%</span></div>
@@ -883,9 +892,11 @@ Anti-patterns to avoid:
           </div>
           {#if !showKeyEdit}
             <div style="display:flex;gap:8px;margin-top:8px;">
-              <button class="save-key-btn" onclick={() => loadUsageLimits()}>Refresh Now</button>
               <button class="save-key-btn" style="color:var(--text-secondary);border-color:var(--border);" onclick={() => showKeyEdit = true}>Edit Key</button>
             </div>
+            {#if usageError}
+              <p style="font-size:11px;color:#f85149;margin:6px 0 0;">{usageError}</p>
+            {/if}
           {:else}
             <div style="margin-top:8px;">
               <input type="password" bind:value={sessionKeyInput} placeholder="sk-ant-sid01-..." style="font-size:12px;margin-bottom:4px;" />
@@ -904,9 +915,56 @@ Anti-patterns to avoid:
             </div>
           {/if}
         </div>
+
+        {#if usageLimits}
+          <div style="margin-top:16px;border-top:1px solid var(--border);padding-top:16px;">
+            <div class="usage-detail-row">
+              <div class="usage-detail-label">Session</div>
+              <div class="usage-detail-bar">
+                <div class="usage-detail-fill" style="width:{usageLimits.sessionPercent}%;background:{usageLimits.sessionPercent > 80 ? '#f85149' : usageLimits.sessionPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
+              </div>
+              <div class="usage-detail-pct" style="color:{usageLimits.sessionPercent > 80 ? '#f85149' : usageLimits.sessionPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.sessionPercent.toFixed(1)}%</div>
+            </div>
+            {#if usageLimits.sessionResets}
+              <div class="usage-detail-resets">Resets {new Date(usageLimits.sessionResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
+            {/if}
+
+            <div class="usage-detail-row" style="margin-top:14px;">
+              <div class="usage-detail-label">Weekly</div>
+              <div class="usage-detail-bar">
+                <div class="usage-detail-fill" style="width:{usageLimits.weeklyAllPercent}%;background:{usageLimits.weeklyAllPercent > 80 ? '#f85149' : usageLimits.weeklyAllPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
+              </div>
+              <div class="usage-detail-pct" style="color:{usageLimits.weeklyAllPercent > 80 ? '#f85149' : usageLimits.weeklyAllPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.weeklyAllPercent.toFixed(1)}%</div>
+            </div>
+            {#if usageLimits.weeklyAllResets}
+              <div class="usage-detail-resets">Resets {new Date(usageLimits.weeklyAllResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
+            {/if}
+
+            {#if usageLimits.weeklySonnetPercent != null}
+              <div class="usage-detail-row" style="margin-top:14px;">
+                <div class="usage-detail-label">Sonnet</div>
+                <div class="usage-detail-bar">
+                  <div class="usage-detail-fill" style="width:{usageLimits.weeklySonnetPercent}%;background:{usageLimits.weeklySonnetPercent > 80 ? '#f85149' : usageLimits.weeklySonnetPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
+                </div>
+                <div class="usage-detail-pct" style="color:{usageLimits.weeklySonnetPercent > 80 ? '#f85149' : usageLimits.weeklySonnetPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.weeklySonnetPercent.toFixed(1)}%</div>
+              </div>
+              {#if usageLimits.weeklySonnetResets}
+                <div class="usage-detail-resets">Resets {new Date(usageLimits.weeklySonnetResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
+              {/if}
+            {/if}
+
+            {#if claudePlan}
+              <div style="margin-top:14px;font-size:11px;color:var(--text-secondary);">Plan: <span style="text-transform:capitalize;color:var(--text-primary);">{claudePlan}</span></div>
+            {/if}
+          </div>
+        {/if}
       {:else}
         <div class="session-key-setup">
-          <p style="font-size:12px;color:var(--text-primary);margin:0 0 8px;">Connect to claude.ai to see live usage limits</p>
+          {#if usageError}
+            <p style="font-size:11px;color:#f85149;margin:0 0 8px;">{usageError}</p>
+          {:else}
+            <p style="font-size:12px;color:var(--text-primary);margin:0 0 8px;">Connect to claude.ai to see live usage limits</p>
+          {/if}
           <label style="margin-bottom:6px;">Session Key
             <input type="password" bind:value={sessionKeyInput} placeholder="sk-ant-sid01-..." style="margin-top:4px;font-size:12px;" />
           </label>
@@ -915,6 +973,7 @@ Anti-patterns to avoid:
             if (sessionKeyInput.trim()) {
               await invoke("save_session_key", { key: sessionKeyInput.trim() });
               sessionKeyConfigured = true;
+              usageError = '';
               await loadUsageLimits();
               usageRefreshInterval = setInterval(loadUsageLimits, 5 * 60 * 1000);
             }
@@ -986,59 +1045,6 @@ Anti-patterns to avoid:
 </div>
 {/if}
 
-{#if showUsageDetail && usageLimits}
-<div class="modal-backdrop" style="animation:fadeIn 0.1s ease-out;">
-  <div class="modal" style="max-width:380px;animation:slideIn 0.15s ease-out;padding:0;">
-    <div style="padding:20px 20px 16px;">
-      <h2 style="font-size:14px;margin:0 0 16px;">Usage</h2>
-
-      <div class="usage-detail-row">
-        <div class="usage-detail-label">Session</div>
-        <div class="usage-detail-bar">
-          <div class="usage-detail-fill" style="width:{usageLimits.sessionPercent}%;background:{usageLimits.sessionPercent > 80 ? '#f85149' : usageLimits.sessionPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
-        </div>
-        <div class="usage-detail-pct" style="color:{usageLimits.sessionPercent > 80 ? '#f85149' : usageLimits.sessionPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.sessionPercent.toFixed(1)}%</div>
-      </div>
-      {#if usageLimits.sessionResets}
-        <div class="usage-detail-resets">Resets {new Date(usageLimits.sessionResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
-      {/if}
-
-      <div class="usage-detail-row" style="margin-top:14px;">
-        <div class="usage-detail-label">Weekly</div>
-        <div class="usage-detail-bar">
-          <div class="usage-detail-fill" style="width:{usageLimits.weeklyAllPercent}%;background:{usageLimits.weeklyAllPercent > 80 ? '#f85149' : usageLimits.weeklyAllPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
-        </div>
-        <div class="usage-detail-pct" style="color:{usageLimits.weeklyAllPercent > 80 ? '#f85149' : usageLimits.weeklyAllPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.weeklyAllPercent.toFixed(1)}%</div>
-      </div>
-      {#if usageLimits.weeklyAllResets}
-        <div class="usage-detail-resets">Resets {new Date(usageLimits.weeklyAllResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
-      {/if}
-
-      {#if usageLimits.weeklySonnetPercent != null}
-        <div class="usage-detail-row" style="margin-top:14px;">
-          <div class="usage-detail-label">Sonnet</div>
-          <div class="usage-detail-bar">
-            <div class="usage-detail-fill" style="width:{usageLimits.weeklySonnetPercent}%;background:{usageLimits.weeklySonnetPercent > 80 ? '#f85149' : usageLimits.weeklySonnetPercent > 50 ? '#d29922' : 'var(--accent)'}"></div>
-          </div>
-          <div class="usage-detail-pct" style="color:{usageLimits.weeklySonnetPercent > 80 ? '#f85149' : usageLimits.weeklySonnetPercent > 50 ? '#d29922' : 'var(--accent)'}">{usageLimits.weeklySonnetPercent.toFixed(1)}%</div>
-        </div>
-        {#if usageLimits.weeklySonnetResets}
-          <div class="usage-detail-resets">Resets {new Date(usageLimits.weeklySonnetResets).toLocaleString(undefined, { month: 'short', day: 'numeric', hour: 'numeric', minute: '2-digit' })}</div>
-        {/if}
-      {/if}
-    </div>
-
-    {#if claudePlan}
-      <div style="padding:0 20px 12px;font-size:11px;color:var(--text-secondary);">Plan: <span style="text-transform:capitalize;color:var(--text-primary);">{claudePlan}</span></div>
-    {/if}
-
-    <div class="modal-actions" style="padding:12px 20px;border-top:1px solid var(--border);">
-      <button onclick={() => showUsageDetail = false}>Close</button>
-      <button class="create-btn" onclick={() => { showUsageDetail = false; loadUsageLimits(); }}>Refresh</button>
-    </div>
-  </div>
-</div>
-{/if}
 
 <style>
   :global(:root) {


### PR DESCRIPTION
## Summary
- Removes the separate usage detail popup modal — clicking usage chips in the bottom bar now opens **Settings > Usage** tab directly
- Adds session key expiry detection: if the API returns auth errors, UI resets to the setup flow with a red error message
- Removes the Refresh Now button (auto-refresh every 5 min still works)

## Test plan
- [ ] Click usage chips in bottom bar → should open Settings modal on Usage tab
- [ ] With no session key configured, click "Set up usage tracking" → same Settings > Usage tab
- [ ] Verify progress bars (Session/Weekly/Sonnet) show inside Usage tab
- [ ] Invalidate session key → verify UI switches back to Connect flow with error message
- [ ] Confirm auto-refresh still updates data every 5 minutes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Clear, human-readable usage error messages; auth-related failures prompt reconnect and clear stale session state.
  * Inline usage breakdown in Settings → Usage showing session, weekly and sonnet metrics, reset times and plan info.

* **UI Changes**
  * Clicking usage chips now opens Settings on the Usage tab (previous usage-detail modal removed).
  * "Refresh Now" button removed; errors shown inline with retry guidance.

* **Bug Fixes**
  * Terminal launch now respects the system shell with a sensible fallback.

* **Documentation**
  * Updated homepage/demo layout and content, added interactive demo elements and a promo video.
  * README includes embedded promo video and updated resource estimate.

* **Style**
  * Hero layout and responsive styles revised; container width increased and new hero/branding styles added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->