### PR TITLE
fix: source .zshrc/.bashrc in shell spawn to find claude binary

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -701,6 +701,7 @@ fn spawn_terminal(
     let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let mut cmd = CommandBuilder::new(&user_shell);
     cmd.arg("-l");
+    cmd.arg("-i");
     cmd.arg("-c");
     cmd.arg(&claude_cmd);
     cmd.cwd(&project_path);
@@ -796,6 +797,7 @@ fn spawn_shell(
     let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     let mut cmd = CommandBuilder::new(&user_shell);
     cmd.arg("-l");
+    cmd.arg("-i");
     cmd.cwd(&project_path);
     if let Some(home) = dirs::home_dir() {
         cmd.env("HOME", home.to_string_lossy().to_string());


### PR DESCRIPTION
## Summary

- **Root cause:** `spawn_terminal()` runs `zsh -l -c "claude ..."` — the `-c` flag makes the shell non-interactive, so zsh skips `.zshrc` (only sourced for interactive shells). Since PATH modifications (homebrew, nvm, npm global bin) typically live in `.zshrc`, the `claude` binary isn't found, resulting in "could not find the claude binary" error.
- **Fix:** Added `-i` (interactive) flag to both `spawn_terminal()` and `spawn_shell()` so `.zshrc`/`.bashrc` are sourced before executing commands. This is the same approach VS Code and other terminal emulators use.
- Applies to both Claude sessions and plain shell terminals.

## Test plan

- [ ] Launch Clauge and start a new Claude session — verify `claude` binary is found and session starts
- [ ] Open a plain shell terminal panel — verify shell has full PATH from `.zshrc`
- [ ] Test with both zsh and bash as default shell

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved terminal shell interactivity by enabling interactive mode during shell initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->