### PR TITLE
fix: security hardening — command injection, process cleanup, mutex poisoning, branch validation

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -67,12 +67,13 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "app"
-version = "1.1.0"
+version = "1.2.0"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "dirs 5.0.1",
  "image",
+ "parking_lot",
  "portable-pty",
  "reqwest",
  "serde",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -38,4 +38,5 @@ tauri-plugin-updater = "2.10.0"
 tauri-plugin-process = "2.3.1"
 tauri-plugin-autostart = "2.5.1"
 tauri-plugin-notification = "2.3.3"
+parking_lot = "0.12"
 

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -658,6 +658,24 @@ fn update_tray_title(app_handle: tauri::AppHandle, title: String) -> Result<(), 
 }
 
 
+/// Resolve the full path to the `claude` binary by asking the user's login shell.
+/// Falls back to just "claude" if resolution fails.
+fn resolve_claude_path() -> String {
+    let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    if let Ok(output) = std::process::Command::new(&user_shell)
+        .args(["-l", "-i", "-c", "which claude"])
+        .output()
+    {
+        if output.status.success() {
+            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+            if !path.is_empty() {
+                return path;
+            }
+        }
+    }
+    "claude".to_string()
+}
+
 /// Spawn a terminal using Tauri's Channel API for streaming PTY output to the frontend.
 /// The `on_output` channel sends TerminalOutputPayload messages directly to JS callback.
 #[tauri::command]
@@ -681,30 +699,26 @@ fn spawn_terminal(
         })
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-    let mut claude_cmd = String::from("claude");
+    let claude_path = resolve_claude_path();
+    eprintln!("[Clauge] Resolved claude binary: {}", claude_path);
+    eprintln!("[Clauge] CWD: {}", project_path);
+
+    let mut cmd = CommandBuilder::new(&claude_path);
+
     if let Some(ref sid) = session_id {
-        claude_cmd.push_str(&format!(" --resume \"{}\"", sid));
+        cmd.arg("--resume");
+        cmd.arg(sid);
     }
     if skip_permissions.unwrap_or(false) {
-        claude_cmd.push_str(" --dangerously-skip-permissions");
+        cmd.arg("--dangerously-skip-permissions");
     }
-    // Inject purpose prompt via --append-system-prompt (persists every turn)
     if let Some(ref prompt) = context_prompt {
         if !prompt.is_empty() {
-            let escaped = prompt.replace('\\', "\\\\").replace('"', "\\\"");
-            claude_cmd.push_str(&format!(" --append-system-prompt \"{}\"", escaped));
+            cmd.arg("--append-system-prompt");
+            cmd.arg(prompt);
         }
     }
 
-    eprintln!("[Clauge] Spawning command (truncated): {}", &claude_cmd[..claude_cmd.len().min(120)]);
-    eprintln!("[Clauge] CWD: {}", project_path);
-
-    let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
-    let mut cmd = CommandBuilder::new(&user_shell);
-    cmd.arg("-l");
-    cmd.arg("-i");
-    cmd.arg("-c");
-    cmd.arg(&claude_cmd);
     cmd.cwd(&project_path);
 
     if let Some(home) = dirs::home_dir() {
@@ -887,6 +901,19 @@ fn resize_terminal(
     Ok(())
 }
 
+#[tauri::command]
+fn kill_terminal(
+    state: State<'_, TerminalState>,
+    terminal_id: String,
+) -> Result<(), String> {
+    let mut terminals = state.terminals.lock();
+    if let Some(mut entry) = terminals.remove(&terminal_id) {
+        let _ = entry.child.kill();
+        eprintln!("[Clauge] Killed terminal {}", terminal_id);
+    }
+    Ok(())
+}
+
 // ---------------------------------------------------------------------------
 // Entry point
 // ---------------------------------------------------------------------------
@@ -926,7 +953,8 @@ pub fn run() {
             spawn_terminal,
             spawn_shell,
             write_to_terminal,
-            resize_terminal
+            resize_terminal,
+            kill_terminal
         ])
         .setup(|app| {
             let setup_start = std::time::Instant::now();
@@ -1023,11 +1051,23 @@ pub fn run() {
         .build(tauri::generate_context!())
         .expect("error while building tauri application")
         .run(|app, event| {
-            if let tauri::RunEvent::Reopen { .. } = event {
-                if let Some(window) = app.get_webview_window("main") {
-                    let _ = window.show();
-                    let _ = window.set_focus();
+            match event {
+                tauri::RunEvent::Reopen { .. } => {
+                    if let Some(window) = app.get_webview_window("main") {
+                        let _ = window.show();
+                        let _ = window.set_focus();
+                    }
                 }
+                tauri::RunEvent::ExitRequested { .. } => {
+                    if let Some(state) = app.try_state::<TerminalState>() {
+                        let mut terminals = state.terminals.lock();
+                        for (id, mut entry) in terminals.drain() {
+                            let _ = entry.child.kill();
+                            eprintln!("[Clauge] Cleaned up terminal {} on exit", id);
+                        }
+                    }
+                }
+                _ => {}
             }
         });
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -336,9 +336,44 @@ fn is_git_repo(path: String) -> Result<bool, String> {
     Ok(output.status.success())
 }
 
+/// Sanitize a branch name to comply with git naming rules.
+/// Removes dangerous characters, prevents flag injection (leading `-`),
+/// and enforces git's naming constraints.
+fn sanitize_branch_name(name: &str) -> String {
+    let sanitized: String = name
+        .chars()
+        .filter(|c| c.is_alphanumeric() || *c == '/' || *c == '-' || *c == '_' || *c == '.')
+        .collect();
+
+    // Collapse consecutive dots/dashes, remove trailing dots/locks
+    let sanitized = sanitized
+        .replace("..", ".")
+        .replace(".lock", "")
+        .trim_matches(|c: char| c == '.' || c == '/' || c == '-')
+        .to_string();
+
+    if sanitized.is_empty() {
+        return "clauge/unnamed".to_string();
+    }
+
+    // Prevent flag injection: if any path segment starts with `-`, prefix it
+    sanitized
+        .split('/')
+        .map(|seg| {
+            if seg.starts_with('-') {
+                format!("x{}", seg)
+            } else {
+                seg.to_string()
+            }
+        })
+        .collect::<Vec<_>>()
+        .join("/")
+}
+
 /// Create a git worktree for session isolation
 #[tauri::command]
 fn create_worktree(project_path: String, branch_name: String) -> Result<String, String> {
+    let branch_name = sanitize_branch_name(&branch_name);
     let worktree_dir = PathBuf::from(&project_path)
         .join(".clauge-worktrees")
         .join(&branch_name);

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::io::{Read, Write};
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
+use parking_lot::Mutex;
 use tauri::ipc::Channel;
 use tauri::menu::{Menu, MenuItem, PredefinedMenuItem, Submenu};
 use tauri::tray::{TrayIconBuilder, TrayIconId};
@@ -775,7 +776,6 @@ fn spawn_terminal(
     state
         .terminals
         .lock()
-        .map_err(|e| format!("Lock error: {}", e))?
         .insert(terminal_id.clone(), entry);
 
     Ok(terminal_id)
@@ -828,7 +828,7 @@ fn spawn_shell(
         }
     });
 
-    state.terminals.lock().map_err(|e| format!("Lock error: {}", e))?
+    state.terminals.lock()
         .insert(terminal_id.clone(), TerminalEntry { master: pty_pair.master, writer, child });
 
     Ok(terminal_id)
@@ -842,8 +842,7 @@ fn write_to_terminal(
 ) -> Result<(), String> {
     let mut terminals = state
         .terminals
-        .lock()
-        .map_err(|e| format!("Lock error: {}", e))?;
+        .lock();
 
     let entry = terminals
         .get_mut(&terminal_id)
@@ -871,8 +870,7 @@ fn resize_terminal(
 ) -> Result<(), String> {
     let terminals = state
         .terminals
-        .lock()
-        .map_err(|e| format!("Lock error: {}", e))?;
+        .lock();
 
     let entry = terminals.get(&terminal_id).ok_or("Terminal not found")?;
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -375,7 +375,8 @@
           try {
             const isGit = await invoke("is_git_repo", { path: profile.projectPath });
             if (isGit) {
-              const branchName = `clauge/${profile.purpose.toLowerCase().replace(/\s+/g, '-')}-${profile.title.toLowerCase().replace(/\s+/g, '-')}`;
+              const rawBranch = `clauge/${profile.purpose.toLowerCase().replace(/\s+/g, '-')}-${profile.title.toLowerCase().replace(/\s+/g, '-')}`;
+              const branchName = rawBranch.replace(/[^a-zA-Z0-9/_\-.]/g, '').replace(/\.{2,}/g, '.').replace(/\.lock/g, '');
               const worktreePath = await invoke("create_worktree", { projectPath: profile.projectPath, branchName });
               spawnPath = worktreePath;
               await invoke("update_profile_worktree", { id: profile.id, worktreePath, worktreeBranch: branchName });

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -527,17 +527,23 @@
 
     await invoke("delete_profile", { id: deletedId });
 
-    // Clean up terminal
+    // Clean up terminal (backend PTY + child process)
     const entry = terminalMap.get(deletedId);
     if (entry) {
+      if (entry.terminalId) {
+        try { await invoke("kill_terminal", { terminalId: entry.terminalId }); } catch(e) {}
+      }
       entry.container.style.display = "none";
       if (entry.term) entry.term.dispose();
       terminalMap.delete(deletedId);
     }
 
-    // Clean up shell
+    // Clean up shell (backend PTY + child process)
     const sEntry = shellMap.get(deletedId);
     if (sEntry) {
+      if (sEntry.terminalId) {
+        try { await invoke("kill_terminal", { terminalId: sEntry.terminalId }); } catch(e) {}
+      }
       sEntry.container.style.display = "none";
       if (sEntry.term) sEntry.term.dispose();
       shellMap.delete(deletedId);


### PR DESCRIPTION
## Summary

Addresses 4 issues found during application review:

- **Command injection via context_prompt (CRITICAL):** `spawn_terminal()` was building a shell command string and passing it to `$SHELL -c "..."`, with only `"` and `\` escaped. Restructured to invoke `claude` directly via `CommandBuilder`, passing each argument individually — no shell interpretation, no injection surface.
- **No PTY/process cleanup (IMPORTANT):** Added `kill_terminal` Tauri command that kills child processes when profiles are deleted. Added `ExitRequested` handler to drain and kill all terminals on app exit, preventing orphaned processes.
- **Mutex poisoning risk (IMPORTANT):** Replaced `std::sync::Mutex` with `parking_lot::Mutex`, which doesn't poison when a thread panics — prevents permanent failure of all terminal operations.
- **Branch name validation (IMPORTANT):** Added `sanitize_branch_name()` that filters dangerous characters, collapses consecutive dots, removes `.lock` suffixes, and prefixes segments starting with `-` to prevent git flag injection. Applied in both Rust backend and frontend.

## Test plan

- [ ] Start a new Claude session — verify claude binary is found and session starts correctly
- [ ] Create a profile with special characters in the title — verify branch name is sanitized
- [ ] Delete a profile — verify the terminal process is killed (check Activity Monitor)
- [ ] Quit the app — verify no orphaned claude/shell processes remain
- [ ] Create a profile with a custom purpose prompt containing `$(echo injected)` — verify no shell execution

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Terminal processes can now be terminated directly from the application.

* **Bug Fixes**
  * Branch names are now automatically cleaned of invalid characters.
  * Improved terminal resource cleanup when exiting the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->