### PR TITLE
feat: configurable Claude binary path + global defaults

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -34,6 +34,8 @@ pub struct SessionProfile {
     pub worktree_branch: Option<String>,
     #[serde(default)]
     pub skip_permissions: bool,
+    #[serde(default)]
+    pub claude_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -189,6 +191,37 @@ fn get_storage_path() -> PathBuf {
     get_storage_dir().join("sessions.json")
 }
 
+fn settings_path() -> PathBuf {
+    get_storage_dir().join("settings.json")
+}
+
+#[derive(Default, Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct GlobalSettings {
+    #[serde(default)]
+    pub claude_path: Option<String>,
+    #[serde(default)]
+    pub default_skip_permissions: Option<bool>,
+}
+
+fn load_settings() -> GlobalSettings {
+    let path = settings_path();
+    if !path.exists() {
+        return GlobalSettings::default();
+    }
+    match std::fs::read_to_string(&path) {
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
+        Err(_) => GlobalSettings::default(),
+    }
+}
+
+fn save_settings_to_disk(s: &GlobalSettings) -> Result<(), String> {
+    let path = settings_path();
+    let json = serde_json::to_string_pretty(s).map_err(|e| e.to_string())?;
+    std::fs::write(&path, json).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
 fn load_profiles() -> Vec<SessionProfile> {
     let path = get_storage_path();
     if !path.exists() {
@@ -248,7 +281,24 @@ fn get_profiles() -> Result<Vec<SessionProfile>, String> {
 }
 
 #[tauri::command]
-fn create_profile(title: String, purpose: String, project_path: String, skip_permissions: Option<bool>, custom_prompt: Option<String>) -> Result<SessionProfile, String> {
+fn get_settings() -> Result<GlobalSettings, String> {
+    Ok(load_settings())
+}
+
+#[tauri::command]
+fn save_settings(settings: GlobalSettings) -> Result<(), String> {
+    let normalized = GlobalSettings {
+        claude_path: settings.claude_path.and_then(|p| {
+            let t = p.trim();
+            if t.is_empty() { None } else { Some(t.to_string()) }
+        }),
+        default_skip_permissions: settings.default_skip_permissions,
+    };
+    save_settings_to_disk(&normalized)
+}
+
+#[tauri::command]
+fn create_profile(title: String, purpose: String, project_path: String, skip_permissions: Option<bool>, custom_prompt: Option<String>, claude_path: Option<String>) -> Result<SessionProfile, String> {
     let mut profiles = load_profiles();
     let now = now_iso8601();
 
@@ -267,6 +317,10 @@ fn create_profile(title: String, purpose: String, project_path: String, skip_per
         worktree_path: None,
         worktree_branch: None,
         skip_permissions: skip_permissions.unwrap_or(false),
+        claude_path: claude_path.and_then(|p| {
+            let t = p.trim();
+            if t.is_empty() { None } else { Some(t.to_string()) }
+        }),
     };
 
     profiles.push(profile.clone());
@@ -693,22 +747,84 @@ fn update_tray_title(app_handle: tauri::AppHandle, title: String) -> Result<(), 
 }
 
 
-/// Resolve the full path to the `claude` binary by asking the user's login shell.
-/// Falls back to just "claude" if resolution fails.
-fn resolve_claude_path() -> String {
+/// Strip ANSI/OSC escape sequences that shell-integration plugins
+/// (iTerm2, VS Code terminal, etc.) inject into interactive-shell output.
+fn strip_terminal_escapes(input: &str) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        let b = bytes[i];
+        if b == 0x1b && i + 1 < bytes.len() {
+            match bytes[i + 1] {
+                b']' => {
+                    // OSC: ESC ] ... (BEL | ESC \)
+                    i += 2;
+                    while i < bytes.len() {
+                        if bytes[i] == 0x07 { i += 1; break; }
+                        if bytes[i] == 0x1b && i + 1 < bytes.len() && bytes[i + 1] == b'\\' { i += 2; break; }
+                        i += 1;
+                    }
+                    continue;
+                }
+                b'[' => {
+                    // CSI: ESC [ ... final-byte in 0x40..=0x7E
+                    i += 2;
+                    while i < bytes.len() {
+                        let c = bytes[i];
+                        i += 1;
+                        if (0x40..=0x7e).contains(&c) { break; }
+                    }
+                    continue;
+                }
+                _ => { i += 2; continue; } // skip ESC + next byte
+            }
+        }
+        if b < 0x20 && b != b'\n' && b != b'\t' { i += 1; continue; }
+        out.push(b as char);
+        i += 1;
+    }
+    out
+}
+
+/// Ask the user's login shell for both `which claude` and `$PATH`.
+/// Returns `(claude_path, path_env)`. Either may be `None` if resolution fails.
+fn resolve_shell_env() -> (Option<String>, Option<String>) {
     let user_shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
     if let Ok(output) = std::process::Command::new(&user_shell)
-        .args(["-l", "-i", "-c", "which claude"])
+        .args(["-l", "-i", "-c", "printf '%s\\n%s\\n' \"$(which claude)\" \"$PATH\""])
         .output()
     {
         if output.status.success() {
-            let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
-            if !path.is_empty() {
-                return path;
-            }
+            let raw = String::from_utf8_lossy(&output.stdout);
+            let stdout = strip_terminal_escapes(&raw);
+            let mut lines = stdout.lines();
+            let claude = lines.next().map(str::trim).filter(|s| !s.is_empty()).map(String::from);
+            let path = lines.next().map(str::trim).filter(|s| !s.is_empty()).map(String::from);
+            return (claude, path);
         }
     }
-    "claude".to_string()
+    (None, None)
+}
+
+/// Build a PATH env value suitable for spawning claude.
+/// Prepends the parent directory of `claude_bin` (if absolute) and
+/// appends the user's login-shell PATH plus sensible defaults.
+fn build_spawn_path(claude_bin: &str, shell_path: Option<&str>) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    if let Some(parent) = std::path::Path::new(claude_bin).parent() {
+        let p = parent.to_string_lossy();
+        if !p.is_empty() { parts.push(p.to_string()); }
+    }
+    if let Some(sp) = shell_path {
+        for p in sp.split(':').filter(|s| !s.is_empty()) {
+            if !parts.iter().any(|x| x == p) { parts.push(p.to_string()); }
+        }
+    }
+    for p in ["/usr/local/bin", "/opt/homebrew/bin", "/usr/bin", "/bin", "/usr/sbin", "/sbin"] {
+        if !parts.iter().any(|x| x == p) { parts.push(p.to_string()); }
+    }
+    parts.join(":")
 }
 
 /// Spawn a terminal using Tauri's Channel API for streaming PTY output to the frontend.
@@ -720,6 +836,7 @@ fn spawn_terminal(
     project_path: String,
     context_prompt: Option<String>,
     skip_permissions: Option<bool>,
+    claude_path: Option<String>,
     on_output: Channel<TerminalOutputPayload>,
 ) -> Result<String, String> {
     let terminal_id = Uuid::new_v4().to_string();
@@ -734,11 +851,24 @@ fn spawn_terminal(
         })
         .map_err(|e| format!("Failed to open PTY: {}", e))?;
 
-    let claude_path = resolve_claude_path();
-    eprintln!("[Clauge] Resolved claude binary: {}", claude_path);
+    let (detected_claude, shell_path) = resolve_shell_env();
+    let global_claude = load_settings()
+        .claude_path
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty());
+    let claude_bin = claude_path
+        .as_ref()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .or(global_claude)
+        .or(detected_claude)
+        .unwrap_or_else(|| "claude".to_string());
+    let path_env = build_spawn_path(&claude_bin, shell_path.as_deref());
+    eprintln!("[Clauge] Resolved claude binary: {}", claude_bin);
     eprintln!("[Clauge] CWD: {}", project_path);
+    eprintln!("[Clauge] PATH: {}", path_env);
 
-    let mut cmd = CommandBuilder::new(&claude_path);
+    let mut cmd = CommandBuilder::new(&claude_bin);
 
     if let Some(ref sid) = session_id {
         cmd.arg("--resume");
@@ -760,6 +890,13 @@ fn spawn_terminal(
         cmd.env("HOME", home.to_string_lossy().to_string());
     }
     cmd.env("TERM", "xterm-256color");
+    cmd.env("PATH", &path_env);
+    if let Ok(shell) = std::env::var("SHELL") {
+        cmd.env("SHELL", shell);
+    }
+    if let Ok(lang) = std::env::var("LANG") {
+        cmd.env("LANG", lang);
+    }
 
     let child = pty_pair
         .slave
@@ -966,6 +1103,8 @@ pub fn run() {
         .manage(TerminalState::default())
         .invoke_handler(tauri::generate_handler![
             get_profiles,
+            get_settings,
+            save_settings,
             create_profile,
             delete_profile,
             rename_profile,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -780,9 +780,17 @@ fn strip_terminal_escapes(input: &str) -> String {
                 _ => { i += 2; continue; } // skip ESC + next byte
             }
         }
+        // Skip non-printable ASCII control chars (except newline/tab)
         if b < 0x20 && b != b'\n' && b != b'\t' { i += 1; continue; }
-        out.push(b as char);
-        i += 1;
+        // Preserve full UTF-8 characters (input is &str, so guaranteed valid)
+        if b < 0x80 {
+            out.push(b as char);
+            i += 1;
+        } else {
+            let ch = input[i..].chars().next().unwrap();
+            out.push(ch);
+            i += ch.len_utf8();
+        }
     }
     out
 }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -210,8 +210,15 @@ fn load_settings() -> GlobalSettings {
         return GlobalSettings::default();
     }
     match std::fs::read_to_string(&path) {
-        Ok(contents) => serde_json::from_str(&contents).unwrap_or_default(),
-        Err(_) => GlobalSettings::default(),
+        Ok(contents) => serde_json::from_str(&contents).unwrap_or_else(|e| {
+            eprintln!("[Clauge] Failed to parse settings.json: {} — using defaults", e);
+            let _ = std::fs::rename(&path, path.with_extension("json.bak"));
+            GlobalSettings::default()
+        }),
+        Err(e) => {
+            eprintln!("[Clauge] Failed to read settings.json: {}", e);
+            GlobalSettings::default()
+        }
     }
 }
 

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -91,6 +91,60 @@
   let modalExistingSessions = $state([]);
   let modalSelectedSession = $state("");
   let modalCustomPrompt = $state("");
+  let modalClaudePath = $state("");
+
+  // Global settings (disk-backed) + UI-only defaults (localStorage)
+  let globalSettings = $state({ claudePath: null, defaultSkipPermissions: false });
+  let defaultPurpose = $state(
+    typeof localStorage !== 'undefined' ? (localStorage.getItem('clauge.defaultPurpose') || '') : ''
+  );
+
+  async function loadGlobalSettings() {
+    try {
+      const s = await invoke('get_settings');
+      globalSettings = {
+        claudePath: s?.claudePath ?? null,
+        defaultSkipPermissions: s?.defaultSkipPermissions ?? false,
+      };
+    } catch(e) { /* keep defaults */ }
+  }
+
+  async function persistGlobalSettings() {
+    try {
+      await invoke('save_settings', { settings: {
+        claudePath: globalSettings.claudePath && globalSettings.claudePath.trim() ? globalSettings.claudePath.trim() : null,
+        defaultSkipPermissions: !!globalSettings.defaultSkipPermissions,
+      }});
+    } catch(e) { statusMsg = 'Settings save failed: ' + e; }
+  }
+
+  function setDefaultPurpose(value) {
+    defaultPurpose = value;
+    if (typeof localStorage !== 'undefined') {
+      if (value) localStorage.setItem('clauge.defaultPurpose', value);
+      else localStorage.removeItem('clauge.defaultPurpose');
+    }
+  }
+
+  function openNewSessionModal() {
+    modalSkipPermissions = !!globalSettings.defaultSkipPermissions;
+    if (!modalPurpose && defaultPurpose) {
+      modalPurpose = defaultPurpose;
+      if (defaultPurpose === 'Custom' && modalPath.trim()) loadExistingSessions(modalPath);
+    }
+    showModal = true;
+  }
+
+  async function browseSettingsClaudePath() {
+    try {
+      const { open } = await import('@tauri-apps/plugin-dialog');
+      const selected = await open({ directory: false, multiple: false, title: 'Select Claude Binary' });
+      if (selected) {
+        globalSettings.claudePath = selected;
+        await persistGlobalSettings();
+      }
+    } catch(e) { statusMsg = 'Browse failed: ' + e; }
+  }
 
   const purposes = [
     { label: "Brainstorming", color: "#d2a8ff" },
@@ -459,6 +513,7 @@
           projectPath: spawnPath,
           contextPrompt: purposePrompt || null,
           skipPermissions: profile.skipPermissions || false,
+          claudePath: profile.claudePath || null,
           onOutput: onOutput,
         });
         entry.terminalId = tid;
@@ -496,6 +551,7 @@
         projectPath: modalPath,
         skipPermissions: modalSkipPermissions,
         customPrompt: modalPurpose === 'Custom' && modalCustomPrompt.trim() ? modalCustomPrompt.trim() : null,
+        claudePath: modalClaudePath.trim() || null,
       });
       // Link existing session if selected (Custom purpose only)
       if (modalSelectedSession) {
@@ -504,7 +560,7 @@
       }
       showModal = false;
       modalPath = ""; modalTitle = ""; modalPurpose = ""; modalSkipPermissions = false;
-      modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = "";
+      modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = "";
       await loadProfiles();
       await selectProfile(profile);
     } catch (e) { statusMsg = "Create failed: " + e; }
@@ -604,8 +660,16 @@
     } catch(e) { statusMsg = "Browse failed: " + e; }
   }
 
+  async function browseClaudePath() {
+    try {
+      const { open } = await import("@tauri-apps/plugin-dialog");
+      const selected = await open({ directory: false, multiple: false, title: "Select Claude Binary" });
+      if (selected) modalClaudePath = selected;
+    } catch(e) { statusMsg = "Browse failed: " + e; }
+  }
+
   function handleGlobalKeydown(e) {
-    if (e.metaKey && e.key === 'n') { e.preventDefault(); showModal = true; }
+    if (e.metaKey && e.key === 'n') { e.preventDefault(); openNewSessionModal(); }
     if (e.metaKey && e.key >= '1' && e.key <= '9') {
       e.preventDefault();
       const idx = parseInt(e.key) - 1;
@@ -613,7 +677,7 @@
     }
     if (e.metaKey && e.key === 'b') { e.preventDefault(); toggleSidebar(); }
     if (e.metaKey && e.key === 'l') { e.preventDefault(); toggleShell(); }
-    if (e.key === 'Escape') { showModal = false; showSettings = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; }
+    if (e.key === 'Escape') { showModal = false; showSettings = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; }
   }
 
   function handleWindowResize() {
@@ -932,6 +996,7 @@ Anti-patterns to avoid:
 
     // Priority 1: Load profiles (fast, <10ms)
     loadProfiles();
+    loadGlobalSettings();
 
     // Priority 2: Load session key + usage limits (fast key read, then ~1.5s API call)
     invoke("load_session_key").then(savedKey => {
@@ -961,7 +1026,7 @@ Anti-patterns to avoid:
             <path fill-rule="evenodd" d="M7.429 1.525a6.593 6.593 0 011.142 0c.036.003.108.036.137.146l.289 1.105c.147.56.55.967.997 1.189.174.086.341.183.501.29.417.278.97.423 1.53.27l1.102-.303c.11-.03.175.016.195.046.219.31.41.641.573.989.014.031.022.11-.059.19l-.815.806c-.411.406-.562.957-.53 1.456a4.588 4.588 0 010 .582c-.032.499.119 1.05.53 1.456l.815.806c.08.08.073.159.059.19a6.494 6.494 0 01-.573.99c-.02.029-.086.074-.195.045l-1.103-.303c-.559-.153-1.112-.008-1.529.27-.16.107-.327.204-.5.29-.449.222-.851.628-.998 1.189l-.289 1.105c-.029.11-.101.143-.137.146a6.613 6.613 0 01-1.142 0c-.036-.003-.108-.037-.137-.146l-.289-1.105c-.147-.56-.55-.967-.997-1.189a4.502 4.502 0 01-.501-.29c-.417-.278-.97-.423-1.53-.27l-1.102.303c-.11.03-.175-.016-.195-.046a6.492 6.492 0 01-.573-.989c-.014-.031-.022-.11.059-.19l.815-.806c.411-.406.562-.957.53-1.456a4.587 4.587 0 010-.582c.032-.499-.119-1.05-.53-1.456l-.815-.806c-.08-.08-.073-.159-.059-.19a6.44 6.44 0 01.573-.99c.02-.029.086-.074.195-.045l1.103.303c.559.153 1.112.008 1.529-.27.16-.107.327-.204.5-.29.449-.222.851-.628.998-1.189l.289-1.105c.029-.11.101-.143.137-.146zM8 0c-.236 0-.47.01-.701.03-.743.065-1.29.615-1.458 1.261l-.29 1.106c-.017.066-.078.158-.211.224a5.994 5.994 0 00-.668.386c-.123.082-.233.117-.3.117h-.013l-1.104-.303c-.659-.18-1.364.019-1.783.667a7.998 7.998 0 00-.747 1.305c-.31.649-.107 1.39.303 1.895l.815.806c.05.048.098.147.088.294a6.084 6.084 0 000 .772c.01.147-.038.246-.088.294l-.815.806c-.41.505-.613 1.246-.303 1.895.216.452.46.882.747 1.305.42.648 1.124.848 1.783.667l1.104-.303c.06-.017.145-.003.3.117.196.131.42.271.668.386.133.066.194.158.212.224l.289 1.106c.169.646.715 1.196 1.458 1.26a8.094 8.094 0 001.402 0c.743-.064 1.29-.614 1.458-1.26l.29-1.106c.017-.066.078-.158.211-.224a5.98 5.98 0 00.668-.386c.123-.082.233-.117.3-.117h.013l1.104.303c.659.18 1.364-.019 1.783-.667.287-.423.531-.853.747-1.305.31-.649.107-1.39-.303-1.895l-.815-.806c-.05-.048-.098-.147-.088-.294a6.1 6.1 0 000-.772c-.01-.147.039-.246.088-.294l.815-.806c.41-.505.613-1.246.303-1.895a7.998 7.998 0 00-.747-1.305c-.42-.648-1.124-.848-1.783-.667l-1.104.303c-.06.017-.145.003-.3-.117a5.994 5.994 0 00-.668-.386c-.133-.066-.194-.158-.212-.224L10.16 1.29C9.99.645 9.444.095 8.701.031A8.094 8.094 0 008 0zm0 5.5a2.5 2.5 0 100 5 2.5 2.5 0 000-5zM6.5 8a1.5 1.5 0 113 0 1.5 1.5 0 01-3 0z"/>
           </svg>
         </button>
-        <button class="new-btn" onclick={() => showModal = true} title="New Session (Cmd+N)">+</button>
+        <button class="new-btn" onclick={openNewSessionModal} title="New Session (Cmd+N)">+</button>
       </div>
     </div>
     <div class="sidebar-content">
@@ -1096,7 +1161,7 @@ Anti-patterns to avoid:
 
 {#if showModal}
 <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-<div class="modal-backdrop" onclick={(e) => { if (e.target === e.currentTarget) { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; } }}>
+<div class="modal-backdrop" onclick={(e) => { if (e.target === e.currentTarget) { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; } }}>
   <div class="modal">
     <h2>New Session</h2>
     <label>Project Folder
@@ -1138,6 +1203,12 @@ Anti-patterns to avoid:
         <textarea class="custom-prompt" bind:value={modalCustomPrompt} placeholder="e.g. Focus on performance optimization, avoid breaking changes..." rows="3"></textarea>
       </label>
     {/if}
+    <label>Claude Binary Path <span style="font-size:10px;color:var(--text-secondary);font-weight:normal;">(optional, overrides auto-detect)</span>
+      <div class="row">
+        <input bind:value={modalClaudePath} placeholder="/usr/local/bin/claude" />
+        <button onclick={browseClaudePath}>Browse</button>
+      </div>
+    </label>
     <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
     <div class="toggle-row">
       <span class="toggle-label">Skip permissions
@@ -1148,7 +1219,7 @@ Anti-patterns to avoid:
       </button>
     </div>
     <div class="modal-actions">
-      <button onclick={() => { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; }}>Cancel</button>
+      <button onclick={() => { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; }}>Cancel</button>
       <button class="create-btn" disabled={!modalPath || !modalTitle || !modalPurpose} onclick={createSession}>Create</button>
     </div>
   </div>
@@ -1165,6 +1236,37 @@ Anti-patterns to avoid:
     </div>
 
     {#if settingsTab === 'settings'}
+      <label>Claude Binary Path <span style="font-size:10px;color:var(--text-secondary);font-weight:normal;">(global fallback, empty = auto-detect)</span>
+        <div class="row">
+          <input
+            bind:value={globalSettings.claudePath}
+            placeholder="auto-detect"
+            onblur={persistGlobalSettings}
+            onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); persistGlobalSettings(); } }}
+          />
+          <button onclick={browseSettingsClaudePath}>Browse</button>
+        </div>
+      </label>
+
+      <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+      <div class="toggle-row">
+        <span class="toggle-label">Skip permissions by default</span>
+        <button class="toggle-switch" class:on={globalSettings.defaultSkipPermissions} onclick={() => { globalSettings.defaultSkipPermissions = !globalSettings.defaultSkipPermissions; persistGlobalSettings(); }}>
+          <span class="toggle-knob"></span>
+        </button>
+      </div>
+
+      <label>Default Purpose
+        <div class="chips" style="margin-top:6px;">
+          <button class="chip" class:selected={defaultPurpose === ''} onclick={() => setDefaultPurpose('')}>None</button>
+          {#each purposes as p}
+            <button class="chip" class:selected={defaultPurpose === p.label}
+              style={defaultPurpose === p.label ? `background:${p.color}33;color:${p.color};border-color:${p.color}` : ''}
+              onclick={() => setDefaultPurpose(p.label)}>{p.label}</button>
+          {/each}
+        </div>
+      </label>
+
       <label>Theme
         <div class="chips" style="margin-top:6px;">
           <button class="chip" class:selected={currentTheme === 'dark'} onclick={() => applyTheme('dark')}>Dark</button>

--- a/src/routes/+page.svelte
+++ b/src/routes/+page.svelte
@@ -92,9 +92,11 @@
   let modalSelectedSession = $state("");
   let modalCustomPrompt = $state("");
   let modalClaudePath = $state("");
+  let modalClaudePathEnabled = $state(false);
 
   // Global settings (disk-backed) + UI-only defaults (localStorage)
   let globalSettings = $state({ claudePath: null, defaultSkipPermissions: false });
+  let settingsClaudePathEnabled = $state(false);
   let defaultPurpose = $state(
     typeof localStorage !== 'undefined' ? (localStorage.getItem('clauge.defaultPurpose') || '') : ''
   );
@@ -106,6 +108,7 @@
         claudePath: s?.claudePath ?? null,
         defaultSkipPermissions: s?.defaultSkipPermissions ?? false,
       };
+      settingsClaudePathEnabled = !!globalSettings.claudePath;
     } catch(e) { /* keep defaults */ }
   }
 
@@ -560,7 +563,7 @@
       }
       showModal = false;
       modalPath = ""; modalTitle = ""; modalPurpose = ""; modalSkipPermissions = false;
-      modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = "";
+      modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; modalClaudePathEnabled = false;
       await loadProfiles();
       await selectProfile(profile);
     } catch (e) { statusMsg = "Create failed: " + e; }
@@ -677,7 +680,7 @@
     }
     if (e.metaKey && e.key === 'b') { e.preventDefault(); toggleSidebar(); }
     if (e.metaKey && e.key === 'l') { e.preventDefault(); toggleShell(); }
-    if (e.key === 'Escape') { showModal = false; showSettings = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; }
+    if (e.key === 'Escape') { showModal = false; showSettings = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; modalClaudePathEnabled = false; }
   }
 
   function handleWindowResize() {
@@ -1161,7 +1164,7 @@ Anti-patterns to avoid:
 
 {#if showModal}
 <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
-<div class="modal-backdrop" onclick={(e) => { if (e.target === e.currentTarget) { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; } }}>
+<div class="modal-backdrop" onclick={(e) => { if (e.target === e.currentTarget) { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; modalClaudePathEnabled = false; } }}>
   <div class="modal">
     <h2>New Session</h2>
     <label>Project Folder
@@ -1203,12 +1206,19 @@ Anti-patterns to avoid:
         <textarea class="custom-prompt" bind:value={modalCustomPrompt} placeholder="e.g. Focus on performance optimization, avoid breaking changes..." rows="3"></textarea>
       </label>
     {/if}
-    <label>Claude Binary Path <span style="font-size:10px;color:var(--text-secondary);font-weight:normal;">(optional, overrides auto-detect)</span>
-      <div class="row">
+    <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+    <div class="toggle-row">
+      <span class="toggle-label">Custom Claude binary</span>
+      <button class="toggle-switch" class:on={modalClaudePathEnabled} onclick={() => { modalClaudePathEnabled = !modalClaudePathEnabled; if (!modalClaudePathEnabled) modalClaudePath = ''; }}>
+        <span class="toggle-knob"></span>
+      </button>
+    </div>
+    {#if modalClaudePathEnabled}
+      <div class="row" style="margin-top:6px;">
         <input bind:value={modalClaudePath} placeholder="/usr/local/bin/claude" />
         <button onclick={browseClaudePath}>Browse</button>
       </div>
-    </label>
+    {/if}
     <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
     <div class="toggle-row">
       <span class="toggle-label">Skip permissions
@@ -1219,7 +1229,7 @@ Anti-patterns to avoid:
       </button>
     </div>
     <div class="modal-actions">
-      <button onclick={() => { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; }}>Cancel</button>
+      <button onclick={() => { showModal = false; modalExistingSessions = []; modalSelectedSession = ""; modalCustomPrompt = ""; modalClaudePath = ""; modalClaudePathEnabled = false; }}>Cancel</button>
       <button class="create-btn" disabled={!modalPath || !modalTitle || !modalPurpose} onclick={createSession}>Create</button>
     </div>
   </div>
@@ -1236,17 +1246,24 @@ Anti-patterns to avoid:
     </div>
 
     {#if settingsTab === 'settings'}
-      <label>Claude Binary Path <span style="font-size:10px;color:var(--text-secondary);font-weight:normal;">(global fallback, empty = auto-detect)</span>
-        <div class="row">
+      <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
+      <div class="toggle-row">
+        <span class="toggle-label">Custom Claude binary path</span>
+        <button class="toggle-switch" class:on={settingsClaudePathEnabled} onclick={() => { settingsClaudePathEnabled = !settingsClaudePathEnabled; if (!settingsClaudePathEnabled) { globalSettings.claudePath = null; persistGlobalSettings(); } }}>
+          <span class="toggle-knob"></span>
+        </button>
+      </div>
+      {#if settingsClaudePathEnabled}
+        <div class="row" style="margin-top:6px;">
           <input
             bind:value={globalSettings.claudePath}
-            placeholder="auto-detect"
+            placeholder="/usr/local/bin/claude"
             onblur={persistGlobalSettings}
             onkeydown={(e) => { if (e.key === 'Enter') { e.preventDefault(); persistGlobalSettings(); } }}
           />
           <button onclick={browseSettingsClaudePath}>Browse</button>
         </div>
-      </label>
+      {/if}
 
       <!-- svelte-ignore a11y_no_static_element_interactions a11y_click_events_have_key_events -->
       <div class="toggle-row">


### PR DESCRIPTION
## Summary

Makes the `claude` binary location user-configurable (both globally and per session) and fixes a class of spawn failures that block users whose `claude` lives outside the default system `PATH`.

## Motivation

Clauge resolves the `claude` binary by asking the user's login shell `which claude`. Two problems surfaced in real use:

1. **`portable-pty` spawns with a minimal `PATH`.** Even when `which claude` returned a correct absolute path like `/Users/me/.local/bin/claude`, spawn still failed with `No viable candidates found in PATH "/usr/bin:/bin:/usr/sbin:/sbin"` because `CommandBuilder` doesn't inherit the parent's environment.

2. **Interactive login shells pollute stdout.** Shell-integration plugins shipped with iTerm2, VS Code's terminal, Warp, etc. emit OSC escape sequences (`ESC ] 1337 ; … BEL`) on every prompt. Running `zsh -l -i -c …` captured those escapes in the output, producing an unspawnable "path" like `\x1b]1337;…\x07/Users/me/.local/bin/claude`.

3. **No escape hatch.** Users who want to pin a specific Claude build (e.g., a nightly, a Volta-managed version) had no way to tell Clauge which binary to use.

## Changes

### Claude binary resolution

`spawn_terminal` now follows a precedence chain:

1. Per-session override (new field on `SessionProfile`)
2. Global setting (`~/.clauge/settings.json`)
3. Login-shell `which claude`
4. Literal `"claude"` (let `portable-pty` do its own lookup)

Added UI:
- **New Session modal** — optional "Claude Binary Path" field with file picker.
- **Settings modal** — "Claude Binary Path" field as a global fallback.

### Spawn environment fixes

- `spawn_terminal` now explicitly sets `PATH` on the child process, composed of the binary's parent directory + the user's login-shell `$PATH` + sensible defaults (`/opt/homebrew/bin`, `/usr/local/bin`, etc.). `SHELL` and `LANG` are forwarded if set.
- Output from the login shell is stripped of ANSI CSI and OSC escape sequences before parsing, so shell-integration plugins no longer break resolution.

### Other global defaults

Same Settings pane also gains:
- **Skip permissions by default** — persisted to disk, prefills the toggle in New Session.
- **Default purpose** — persisted to `localStorage`, prefills the purpose chip in New Session.

All three global settings are optional; unset means today's behavior.

### Storage split

- Disk (`~/.clauge/settings.json`, new): values `spawn_terminal` reads directly — `claudePath`, `defaultSkipPermissions`.
- localStorage: UI-only prefs — `clauge.defaultPurpose` (matches existing pattern with theme/accent).

## Test plan

- [x] Empty state: delete `~/.clauge/settings.json`, open New Session — works as before via shell detection
- [x] Global `claudePath` only: set in Settings, start a new session — logs show the global value is used
- [x] Per-session overrides global: both set, per-session wins
- [x] Default purpose: set `Development`, open New Session — chip preselected
- [x] Default skip-permissions: toggle on, open New Session — toggle on
- [x] Spawn from `/Users/*/.local/bin/claude` succeeds (previously failed with PATH error)
- [x] Spawn under iTerm2 on first launch no longer captures OSC escapes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Configure Claude binary path globally in Settings or override per-session with a Browse picker; defaults persist and can be applied to new sessions.
  * Save a default "skip permissions" option and a default purpose that pre-fills the New Session modal.
  * Cmd/Ctrl+N opens the New Session modal; modal teardown clears temporary Claude path and toggle.

* **Bug Fixes**
  * More reliable PATH resolution when launching terminals; spawned processes now receive SHELL and LANG and use a clear precedence for selecting the Claude executable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->